### PR TITLE
Remove unused PyYAML dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ classifiers = [
 ]
 dependencies = [
     "boto3>=1.26.0",
-    "PyYAML>=6.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Closes #5
Removed PyYAML from dependencies as it was not being used in the codebase.