### PR TITLE
Add configuration parameters for excluded channels EPG filtering

### DIFF
--- a/src/m3u_simple_filter/config.py
+++ b/src/m3u_simple_filter/config.py
@@ -66,6 +66,16 @@ class Config:
         return int(os.getenv('EPG_PAST_RETENTION_DAYS', '0'))
 
     @property
+    def EXCLUDED_CHANNELS_FUTURE_LIMIT_DAYS(self) -> int:
+        """Number of days in the future to retain programs for excluded channels"""
+        return int(os.getenv('EXCLUDED_CHANNELS_FUTURE_LIMIT_DAYS', '1'))
+
+    @property
+    def EXCLUDED_CHANNELS_PAST_LIMIT_HOURS(self) -> int:
+        """Number of hours in the past (before now) to retain programs for excluded channels that have already ended"""
+        return int(os.getenv('EXCLUDED_CHANNELS_PAST_LIMIT_HOURS', '1'))
+
+    @property
     def LOCAL_FILTERED_PLAYLIST_PATH(self) -> str:
         """Local path for filtered playlist, using S3_OBJECT_KEY environment variable or default"""
         return os.getenv('S3_OBJECT_KEY', 'playlist.m3u')


### PR DESCRIPTION
This PR adds new configuration parameters to control EPG filtering for excluded channels:
- EXCLUDED_CHANNELS_FUTURE_LIMIT_DAYS: Number of days in the future to retain programs for excluded channels
- EXCLUDED_CHANNELS_PAST_LIMIT_HOURS: Number of hours in the past to retain programs for excluded channels that have already ended

Also updates the filtering logic to use these parameters and improves test reliability by adding current_time_override parameter.

Fixes #16