### PR TITLE
feat: add numeric suffixes to CHANNELS_KEEP_ALL_VARIANTS channels

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -141,8 +141,9 @@ The issue should include:
 - **Root Cause**: Technical explanation of why it happened
 - **Impact**: What was affected
 
-### 2. Commit Changes
+### 2. Create Branch and Commit Changes
 ```bash
+git checkout -b <type-feature>
 git add <modified files>
 git commit -m "<type>: <descriptive message>
 

--- a/src/m3u_simple_filter/m3u_processor.py
+++ b/src/m3u_simple_filter/m3u_processor.py
@@ -633,9 +633,20 @@ def remove_duplicates_and_apply_hd_preference(content: str) -> str:
         # Special case: keep all variants for configured channels (e.g., TLC)
         channels_keep_all = [c.lower() for c in Config.get_channels_keep_all_variants()]
         if key in channels_keep_all:
-            final_channel_entries.extend(variants)
-            if len(variants) > 1:
-                logger.debug(f"Keeping all {len(variants)} variants for '{key}' (configured to keep all): {[ext.rsplit(',', 1)[1].strip() for ext, _ in variants]}")
+            # Add numeric suffix to differentiate channels with same name
+            for idx, (extinf_line, entry_lines) in enumerate(variants, start=1):
+                # Extract channel name and add suffix
+                parts = extinf_line.rsplit(',', 1)
+                if len(parts) > 1:
+                    channel_name = parts[1].strip()
+                    new_channel_name = f"{channel_name} #{idx}"
+                    # Update the EXTINF line with new channel name
+                    new_extinf_line = f"{parts[0]},{new_channel_name}"
+                    final_channel_entries.append((new_extinf_line, entry_lines))
+                    logger.debug(f"Added suffix to channel '{channel_name}' -> '{new_channel_name}'")
+                else:
+                    final_channel_entries.append((extinf_line, entry_lines))
+            logger.info(f"Kept all {len(variants)} variants for '{key}' with numeric suffixes")
             continue
 
         # Separate HD and non-HD versions


### PR DESCRIPTION
## Changes

- Modified `remove_duplicates_and_apply_hd_preference()` in `m3u_processor.py`
- Added numeric suffixes (`#1`, `#2`, `#3`, etc.) to channel names in `CHANNELS_KEEP_ALL_VARIANTS`

## Problem Fixed

TV boxes get confused when adding channels to favorites because multiple channels have identical names (e.g., multiple 'Москва 24' and 'TLC' from different providers). The box cannot distinguish between channels with the same name.

## Result

All variants of configured channels are now preserved with unique names:
- **Before**: 4 channels all named 'TLC', 9 channels all named 'Москва 24'
- **After**: 'TLC #1', 'TLC #2', 'TLC #3', 'TLC #4' and 'Москва 24 #1' through 'Москва 24 #9'

Users can now properly add these channels to favorites on their TV box.

Closes #51