### PR TITLE
Remove duplicate URLs and sort playlist alphabetically

### DIFF
--- a/internal/m3u/m3u_test.go
+++ b/internal/m3u/m3u_test.go
@@ -64,6 +64,186 @@ http://example.com/2duplicate`
 	}
 }
 
+func TestSortPlaylistAlphabetically(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		order    []string // expected channel name order
+	}{
+		{
+			name: "sort A-Z",
+			input: `#EXTM3U
+#EXTINF:-1 group-title="Новости",Channel C
+http://example.com/c.m3u8
+#EXTINF:-1 group-title="Спорт",Channel A
+http://example.com/a.m3u8
+#EXTINF:-1 group-title="Кино",Channel B
+http://example.com/b.m3u8`,
+			order: []string{"Channel A", "Channel B", "Channel C"},
+		},
+		{
+			name: "case-insensitive sort",
+			input: `#EXTM3U
+#EXTINF:-1,channel z
+http://example.com/z.m3u8
+#EXTINF:-1,Channel A
+http://example.com/a.m3u8
+#EXTINF:-1,CHANNEL B
+http://example.com/b.m3u8`,
+			order: []string{"Channel A", "CHANNEL B", "channel z"},
+		},
+		{
+			name: "preserves #N suffixes",
+			input: `#EXTM3U
+#EXTINF:-1,Channel B #2
+http://example.com/b2.m3u8
+#EXTINF:-1,Channel A
+http://example.com/a.m3u8
+#EXTINF:-1,Channel B #1
+http://example.com/b1.m3u8`,
+			order: []string{"Channel A", "Channel B #1", "Channel B #2"},
+		},
+		{
+			name: "stable sort keeps original order for equal names",
+			input: `#EXTM3U
+#EXTINF:-1,Same Name
+http://example.com/1.m3u8
+#EXTINF:-1,Same Name
+http://example.com/2.m3u8`,
+			order: []string{"Same Name", "Same Name"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := SortPlaylistAlphabetically(tc.input)
+
+			// Extract channel names in order.
+			var names []string
+			for _, line := range strings.Split(result, "\n") {
+				if strings.HasPrefix(strings.TrimSpace(line), "#EXTINF:") {
+					parts := strings.SplitN(line, ",", 2)
+					if len(parts) > 1 {
+						names = append(names, strings.TrimSpace(parts[1]))
+					}
+				}
+			}
+
+			if len(names) != len(tc.order) {
+				t.Fatalf("expected %d channels, got %d: %v", len(tc.order), len(names), names)
+			}
+
+			for i, expected := range tc.order {
+				if names[i] != expected {
+					t.Errorf("position %d: expected %q, got %q", i, expected, names[i])
+				}
+			}
+		})
+	}
+}
+
+func TestRemoveDuplicateURLs(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		wantURLs int // expected number of unique URLs
+		checks   []string // substrings that must be present
+		notChecks []string // substrings that must NOT be present
+	}{
+		{
+			name: "deduplicate by URL, merge attributes, keep longest name",
+			input: `#EXTM3U
+#EXTINF:-1 group-title="Общие" tvg-id="1000" tvg-logo="http://epg.one/img/1000.png" tvg-rec="0",ОТР HD
+http://example.com/otr.m3u8
+#EXTINF:-1 tvg-rec="7",ОТР
+http://example.com/otr.m3u8`,
+			wantURLs: 1,
+			checks:   []string{`group-title="Общие"`, `tvg-id="1000"`, `tvg-logo="http://epg.one/img/1000.png"`, `tvg-rec="0"`, `ОТР HD`},
+			notChecks: nil,
+		},
+		{
+			name: "different URLs kept separate",
+			input: `#EXTM3U
+#EXTINF:-1 group-title="Общие" tvg-id="1000",Channel A
+http://example.com/a.m3u8
+#EXTINF:-1 group-title="Новости" tvg-id="2000",Channel B
+http://example.com/b.m3u8`,
+			wantURLs: 2,
+			checks:   []string{`Channel A`, `Channel B`, `http://example.com/a.m3u8`, `http://example.com/b.m3u8`},
+			notChecks: nil,
+		},
+		{
+			name: "merge fills missing tvg-logo from other entry",
+			input: `#EXTM3U
+#EXTINF:-1 tvg-id="500" tvg-logo="http://epg.one/img/500.png",Channel X
+http://example.com/x.m3u8
+#EXTINF:-1 tvg-id="500",Channel X Long Name Version
+http://example.com/x.m3u8`,
+			wantURLs: 1,
+			checks:   []string{`tvg-logo="http://epg.one/img/500.png"`, `Channel X Long Name Version`},
+			notChecks: []string{`Channel X\nhttp`}, // only the longest name should appear
+		},
+		{
+			name: "no duplicates passes through unchanged",
+			input: `#EXTM3U
+#EXTINF:-1 group-title="Общие" tvg-id="100",Channel 1
+http://example.com/1.m3u8
+#EXTINF:-1 group-title="Новости" tvg-id="200",Channel 2
+http://example.com/2.m3u8
+#EXTINF:-1 group-title="Спорт" tvg-id="300",Channel 3
+http://example.com/3.m3u8`,
+			wantURLs: 3,
+			checks:   []string{`Channel 1`, `Channel 2`, `Channel 3`},
+			notChecks: nil,
+		},
+		{
+			name: "three duplicate URLs merged into one",
+			input: `#EXTM3U
+#EXTINF:-1 group-title="A" tvg-id="1" tvg-rec="0",Short
+http://example.com/same.m3u8
+#EXTINF:-1 group-title="B" tvg-rec="5",Medium Name
+http://example.com/same.m3u8
+#EXTINF:-1 tvg-id="3" tvg-logo="http://logo.png",The Longest Channel Name Here
+http://example.com/same.m3u8`,
+			wantURLs: 1,
+			checks:   []string{`The Longest Channel Name Here`, `tvg-rec="0"`, `group-title="A"`, `tvg-logo="http://logo.png"`},
+			notChecks: []string{`Short`, `Medium Name`},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := RemoveDuplicateURLs(tc.input)
+
+			// Count unique URLs in result.
+			_, entries := ParseChannelEntries(strings.Split(result, "\n"))
+			urls := make(map[string]bool)
+			for _, e := range entries {
+				for _, extra := range e.ExtraLines {
+					if strings.HasPrefix(strings.TrimSpace(extra), "http") {
+						urls[strings.TrimSpace(extra)] = true
+					}
+				}
+			}
+			if len(urls) != tc.wantURLs {
+				t.Errorf("expected %d unique URLs, got %d", tc.wantURLs, len(urls))
+			}
+
+			for _, check := range tc.checks {
+				if !strings.Contains(result, check) {
+					t.Errorf("expected result to contain %q", check)
+				}
+			}
+
+			for _, notCheck := range tc.notChecks {
+				if strings.Contains(result, notCheck) {
+					t.Errorf("expected result NOT to contain %q", notCheck)
+				}
+			}
+		})
+	}
+}
+
 func TestRemoveDuplicatesWithTVGRec(t *testing.T) {
 	content := `#EXTM3U
 #EXTINF:-1 tvg-id="711" tvg-rec="3",Channel 1

--- a/internal/m3u/processor.go
+++ b/internal/m3u/processor.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/ozyab/iptv/internal/config"
@@ -23,6 +24,10 @@ var (
 	regCategoriesFile = regexp.MustCompile(`group-title="([^"]+)".*?tvg-id="([^"]+)".+?,(.+)`) // categories.txt parser
 	regGroupTitleAttr = regexp.MustCompile(`group-title="[^"]*"`)                          // for replacement
 	regTvgIDAttr     = regexp.MustCompile(`tvg-id="[^"]*"`)                              // for replacement
+	regTvgLogo       = regexp.MustCompile(`tvg-logo="([^"]*)"`)                          // tvg-logo attribute (capture)
+	regTvgRec        = regexp.MustCompile(`tvg-rec="([^"]*)"`)                           // tvg-rec attribute (capture)
+	regTvgLogoAttr   = regexp.MustCompile(`tvg-logo="[^"]*"`)                            // for replacement
+	regTvgRecAttr    = regexp.MustCompile(`tvg-rec="[^"]*"`)                             // for replacement
 )
 
 // suffixesToRemove lists patterns stripped during name normalization.
@@ -170,7 +175,9 @@ func FilterContent(content string, categoriesToRemove, channelNamesToExclude []s
 		}
 	}
 
-	processed := RemoveDuplicatesAndApplyHDPref(strings.Join(filteredLines, "\n"))
+	contentNoDups := RemoveDuplicateURLs(strings.Join(filteredLines, "\n"))
+	processed := RemoveDuplicatesAndApplyHDPref(contentNoDups)
+	processed = SortPlaylistAlphabetically(processed)
 	origCh := CountChannels(content)
 	procCh := CountChannels(processed)
 	logger.Info("Filtering complete: %d channels -> %d channels", origCh, procCh)
@@ -302,6 +309,156 @@ func ApplyChannelMetadata(content string, categoriesMapping map[string]map[strin
 		logger.Info("Updated metadata: %d group-title, %d tvg-id from categories file", updatedGroup, updatedTvgID)
 	}
 	return strings.Join(lines, "\n")
+}
+
+// RemoveDuplicateURLs removes entries with duplicate URLs, keeping only one entry per unique URL.
+// For duplicate entries, it merges attributes (tvg-id, group-title, tvg-logo, tvg-rec) by taking
+// the first non-empty value and keeps the longest channel name.
+func RemoveDuplicateURLs(content string) string {
+	lines := strings.Split(content, "\n")
+	headers, entries := ParseChannelEntries(lines)
+
+	// Group entries by URL.
+	urlGroups := make(map[string][]ChannelEntry)
+	var noURLEntries []ChannelEntry
+
+	for _, entry := range entries {
+		url := ""
+		for _, extraLine := range entry.ExtraLines {
+			trimmed := strings.TrimSpace(extraLine)
+			if strings.HasPrefix(trimmed, "http") {
+				url = trimmed
+				break
+			}
+		}
+		if url != "" {
+			urlGroups[url] = append(urlGroups[url], entry)
+		} else {
+			noURLEntries = append(noURLEntries, entry)
+		}
+	}
+
+	var dedupedEntries []ChannelEntry
+	totalRemoved := 0
+
+	for _, group := range urlGroups {
+		if len(group) <= 1 {
+			dedupedEntries = append(dedupedEntries, group...)
+			continue
+		}
+
+		// Merge attributes: take first non-empty value from any entry.
+		mergedTvgID := ""
+		mergedGroupTitle := ""
+		mergedTvgLogo := ""
+		mergedTvgRec := ""
+		longestName := ""
+
+		for _, entry := range group {
+			extinfLine := entry.EXTINFLine
+
+			if m := regTvgID.FindStringSubmatch(extinfLine); len(m) > 1 && m[1] != "" && mergedTvgID == "" {
+				mergedTvgID = m[1]
+			}
+			if m := regGroupTitle.FindStringSubmatch(extinfLine); len(m) > 1 && m[1] != "" && mergedGroupTitle == "" {
+				mergedGroupTitle = m[1]
+			}
+			if m := regTvgLogo.FindStringSubmatch(extinfLine); len(m) > 1 && m[1] != "" && mergedTvgLogo == "" {
+				mergedTvgLogo = m[1]
+			}
+			if m := regTvgRec.FindStringSubmatch(extinfLine); len(m) > 1 && m[1] != "" && mergedTvgRec == "" {
+				mergedTvgRec = m[1]
+			}
+
+			// Longest channel name wins.
+			parts := strings.SplitN(extinfLine, ",", 2)
+			if len(parts) > 1 {
+				name := strings.TrimSpace(parts[1])
+				if len(name) > len(longestName) {
+					longestName = name
+				}
+			}
+		}
+
+		// Build merged EXTINF line from the first entry's structure.
+		firstEntry := group[0]
+		extinfPart := strings.SplitN(firstEntry.EXTINFLine, ",", 2)[0]
+
+		// Remove all existing attribute values.
+		extinfPart = regGroupTitleAttr.ReplaceAllString(extinfPart, "")
+		extinfPart = regTvgIDAttr.ReplaceAllString(extinfPart, "")
+		extinfPart = regTvgLogoAttr.ReplaceAllString(extinfPart, "")
+		extinfPart = regTvgRecAttr.ReplaceAllString(extinfPart, "")
+
+		// Clean up extra whitespace.
+		extinfPart = strings.TrimSpace(extinfPart)
+
+		// Add merged attributes in consistent order.
+		if mergedGroupTitle != "" {
+			extinfPart += fmt.Sprintf(` group-title="%s"`, mergedGroupTitle)
+		}
+		if mergedTvgID != "" {
+			extinfPart += fmt.Sprintf(` tvg-id="%s"`, mergedTvgID)
+		}
+		if mergedTvgLogo != "" {
+			extinfPart += fmt.Sprintf(` tvg-logo="%s"`, mergedTvgLogo)
+		}
+		if mergedTvgRec != "" {
+			extinfPart += fmt.Sprintf(` tvg-rec="%s"`, mergedTvgRec)
+		}
+
+		mergedLine := extinfPart + "," + longestName
+
+		dedupedEntries = append(dedupedEntries, ChannelEntry{
+			EXTINFLine: mergedLine,
+			ExtraLines: firstEntry.ExtraLines,
+		})
+		totalRemoved += len(group) - 1
+	}
+
+	// Append entries without URLs (kept as-is).
+	dedupedEntries = append(dedupedEntries, noURLEntries...)
+
+	if totalRemoved > 0 {
+		logger.Info("Removed %d duplicate URLs from playlist", totalRemoved)
+	}
+
+	var finalLines []string
+	finalLines = append(finalLines, headers...)
+	for _, entry := range dedupedEntries {
+		finalLines = append(finalLines, entry.EXTINFLine)
+		finalLines = append(finalLines, entry.ExtraLines...)
+	}
+	return strings.Join(finalLines, "\n")
+}
+
+// SortPlaylistAlphabetically sorts playlist entries alphabetically by channel name (case-insensitive).
+func SortPlaylistAlphabetically(content string) string {
+	lines := strings.Split(content, "\n")
+	headers, entries := ParseChannelEntries(lines)
+
+	sort.SliceStable(entries, func(i, j int) bool {
+		nameI := channelNameFromEntry(entries[i])
+		nameJ := channelNameFromEntry(entries[j])
+		return strings.ToLower(nameI) < strings.ToLower(nameJ)
+	})
+
+	var finalLines []string
+	finalLines = append(finalLines, headers...)
+	for _, entry := range entries {
+		finalLines = append(finalLines, entry.EXTINFLine)
+		finalLines = append(finalLines, entry.ExtraLines...)
+	}
+	return strings.Join(finalLines, "\n")
+}
+
+// channelNameFromEntry extracts the channel name (part after comma) from an EXTINF line.
+func channelNameFromEntry(entry ChannelEntry) string {
+	parts := strings.SplitN(entry.EXTINFLine, ",", 2)
+	if len(parts) > 1 {
+		return strings.TrimSpace(parts[1])
+	}
+	return ""
 }
 
 func AddTvgIDsToPlaylist(content string, epgNameToIDMap map[string]string) string {


### PR DESCRIPTION
## Что сделано

### 1. Дедупликация по URL (`RemoveDuplicateURLs`)
- Удаляет дублирующиеся записи с одинаковым URL
- При слиянии берёт первое непустое значение из tvg-id, group-title, tvg-logo, tvg-rec
- Берёт самое длинное имя канала
- Выполняется **до** добавления суффиксов `#1`/`#2`

### 2. Сортировка по алфавиту (`SortPlaylistAlphabetically`)
- Сортирует каналы A→Z по имени (регистронезависимо)
- Выполняется **после** добавления суффиксов `#1`/`#2`
- Использует устойчивую сортировку для сохранения порядка одинаковых имён

Closes # (issue will be linked after creation)