### PR TITLE
fix: remove duplicate actions/cache step causing build errors

### DIFF
--- a/.github/workflows/filter-m3u.yml
+++ b/.github/workflows/filter-m3u.yml
@@ -39,16 +39,7 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version: '1.25'
-
-    - name: Cache Go modules
-      uses: actions/cache@v4
-      with:
-        path: |
-          ~/go/pkg/mod
-          ~/.cache/go-build
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
+        cache: true
 
     - name: Run tests
       run: go test ./... -v -count=1
@@ -71,16 +62,7 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version: '1.25'
-
-    - name: Cache Go modules
-      uses: actions/cache@v4
-      with:
-        path: |
-          ~/go/pkg/mod
-          ~/.cache/go-build
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
+        cache: true
 
     - name: Set dry-run mode for pull requests
       if: github.event_name == 'pull_request'


### PR DESCRIPTION
## Проблема

В CI появлялись 20+ ошибок `Cannot open: File exists` при распаковке кеша Go-модулей.

## Причина

Конфликт между двумя кешами:
- `actions/setup-go@v5` (с `cache: true` сам кеширует `~/go/pkg/mod`)
- `actions/cache@v4` (кешировал те же директории вручную)

## Решение

Убрал ручной `actions/cache@v4`, т.к. `setup-go@v5` уже делает это автоматически.

Closes #64