### PR TITLE
feat: add new excluded categories (religion, adult/xxx, support-project, info)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -123,7 +123,16 @@ func (c *Config) LocalFilteredEPGPath() string {
 }
 
 // CategoriesToRemove is the deny-list of channel groups to filter out.
-var CategoriesToRemove = []string{"Взрослые"}
+var CategoriesToRemove = []string{
+	"Взрослые",
+	"Религия",
+	"Религиозные",
+	"40.РЕЛИГИЯ 🧙‍♂️",
+	"Adult (18+) ❤️",
+	"XXX (18+) 🔞",
+	"💲💲💲Поддержи Проект💲💲💲",
+	"🔺 INFO 🔺",
+}
 
 // ChannelNamesToExclude lists channels removed by name substring match (case-insensitive).
 var ChannelNamesToExclude = []string{

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -68,11 +68,14 @@ func TestLocalPlaylistPaths(t *testing.T) {
 }
 
 func TestCategoriesToRemove(t *testing.T) {
-	if len(CategoriesToRemove) != 1 {
-		t.Errorf("expected 1 category, got %d", len(CategoriesToRemove))
+	expected := []string{"Взрослые", "Религия", "Религиозные", "40.РЕЛИГИЯ 🧙‍♂️", "Adult (18+) ❤️", "XXX (18+) 🔞", "💲💲💲Поддержи Проект💲💲💲", "🔺 INFO 🔺"}
+	if len(CategoriesToRemove) != len(expected) {
+		t.Errorf("expected %d categories, got %d", len(expected), len(CategoriesToRemove))
 	}
-	if CategoriesToRemove[0] != "Взрослые" {
-		t.Errorf("expected 'Взрослые', got '%s'", CategoriesToRemove[0])
+	for i, v := range expected {
+		if CategoriesToRemove[i] != v {
+			t.Errorf("expected category %q, got %q", v, CategoriesToRemove[i])
+		}
 	}
 }
 


### PR DESCRIPTION
## Описание
Добавлены новые категории в список исключений `CategoriesToRemove`

## Изменения
- `internal/config/config.go`: `CategoriesToRemove` расширен с 1 до 8 элементов:
- "Религия", "Религиозные", "40.РЕЛИГИЯ 🧙‍♂️"
- "Adult (18+) ❤️", "XXX (18+) 🔞"
- "💲💲💲Поддержи Проект💲💲💲", "🔺 INFO 🔺"
- существующая "Взрослые" сохранена
- `internal/config/config_test.go`: обновлён тест `TestCategoriesToRemove`

Closes #67