### PR TITLE
feat: sequential superscript numbering for all channels

### DIFF
--- a/internal/m3u/m3u_test.go
+++ b/internal/m3u/m3u_test.go
@@ -38,32 +38,6 @@ http://example.com/3`
 	}
 }
 
-func TestRemoveDuplicatesAndApplyHDPref(t *testing.T) {
-	content := `#EXTM3U
-#EXTINF:-1 tvg-id="711",Channel 1
-http://example.com/1
-#EXTINF:-1 tvg-id="711",Channel 1 HD
-http://example.com/1hd
-#EXTINF:-1 tvg-id="162",Channel 2
-http://example.com/2
-#EXTINF:-1 tvg-id="162",Channel 2
-http://example.com/2duplicate`
-
-	result := RemoveDuplicatesAndApplyHDPref(content)
-	if !strings.Contains(result, "Channel 1") {
-		t.Error("expected 'Channel 1' in result")
-	}
-	if !strings.Contains(result, "Channel 1 HD") {
-		t.Error("expected 'Channel 1 HD' in result")
-	}
-	if !strings.Contains(result, "Channel 2 #1") {
-		t.Error("expected 'Channel 2 #1' in result")
-	}
-	if !strings.Contains(result, "Channel 2 #2") {
-		t.Error("expected 'Channel 2 #2' in result")
-	}
-}
-
 func TestSortPlaylistAlphabetically(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -93,15 +67,15 @@ http://example.com/b.m3u8`,
 			order: []string{"Channel A", "CHANNEL B", "channel z"},
 		},
 		{
-			name: "preserves #N suffixes",
+			name: "sorts correctly with superscript suffixes",
 			input: `#EXTM3U
-#EXTINF:-1,Channel B #2
+#EXTINF:-1,Channel B ²
 http://example.com/b2.m3u8
 #EXTINF:-1,Channel A
 http://example.com/a.m3u8
-#EXTINF:-1,Channel B #1
+#EXTINF:-1,Channel B ¹
 http://example.com/b1.m3u8`,
-			order: []string{"Channel A", "Channel B #1", "Channel B #2"},
+			order: []string{"Channel A", "Channel B ²", "Channel B ¹"},
 		},
 		{
 			name: "stable sort keeps original order for equal names",
@@ -244,41 +218,39 @@ http://example.com/same.m3u8`,
 	}
 }
 
-func TestRemoveDuplicatesWithTVGRec(t *testing.T) {
+func TestAddSequentialNumbers(t *testing.T) {
 	content := `#EXTM3U
-#EXTINF:-1 tvg-id="711" tvg-rec="3",Channel 1
-http://example.com/1low
-#EXTINF:-1 tvg-id="711" tvg-rec="7",Channel 1
-http://example.com/1high
-#EXTINF:-1 tvg-id="162" tvg-rec="0",Channel 2
-http://example.com/2low
-#EXTINF:-1 tvg-id="162" tvg-rec="5",Channel 2
-http://example.com/2high`
+#EXTINF:-1 tvg-id="711",Channel A
+http://example.com/a
+#EXTINF:-1 tvg-id="162",Channel B
+http://example.com/b
+#EXTINF:-1 tvg-id="711",Channel A
+http://example.com/a2
+#EXTINF:-1 tvg-id="999",Channel C
+http://example.com/c`
 
-	result := RemoveDuplicatesAndApplyHDPref(content)
-	if !strings.Contains(result, "Channel 1 #1") {
-		t.Error("expected 'Channel 1 #1' in result")
+	result := AddSequentialNumbers(content)
+
+	tests := []struct {
+		name     string
+		original string
+		renamed  string
+	}{
+		{"channel 1", "Channel A", "Channel A ¹"},
+		{"channel 2", "Channel B", "Channel B ²"},
+		{"channel 3", "Channel A", "Channel A ³"},
+		{"channel 4", "Channel C", "Channel C ⁴"},
 	}
-	if !strings.Contains(result, "Channel 1 #2") {
-		t.Error("expected 'Channel 1 #2' in result")
-	}
-	if !strings.Contains(result, `tvg-rec="3"`) {
-		t.Error("expected tvg-rec=3 in result")
-	}
-	if !strings.Contains(result, `tvg-rec="7"`) {
-		t.Error("expected tvg-rec=7 in result")
-	}
-	if !strings.Contains(result, "Channel 2 #1") {
-		t.Error("expected 'Channel 2 #1' in result")
-	}
-	if !strings.Contains(result, "Channel 2 #2") {
-		t.Error("expected 'Channel 2 #2' in result")
-	}
-	if !strings.Contains(result, `tvg-rec="0"`) {
-		t.Error("expected tvg-rec=0 in result")
-	}
-	if !strings.Contains(result, `tvg-rec="5"`) {
-		t.Error("expected tvg-rec=5 in result")
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if strings.Contains(result, tc.original+",") {
+				t.Errorf("expected original name %q to be renamed to %q", tc.original, tc.renamed)
+			}
+			if !strings.Contains(result, tc.renamed) {
+				t.Errorf("expected renamed channel %q in result", tc.renamed)
+			}
+		})
 	}
 }
 

--- a/internal/m3u/processor.go
+++ b/internal/m3u/processor.go
@@ -30,16 +30,7 @@ var (
 	regTvgRecAttr    = regexp.MustCompile(`tvg-rec="[^"]*"`)                             // for replacement
 )
 
-// suffixesToRemove lists patterns stripped during name normalization.
-var suffixesToRemove = []*regexp.Regexp{
-	regexp.MustCompile(`\s*\bhd\b\s*`),
-	regexp.MustCompile(`\s*\borig\b\s*`),
-	regexp.MustCompile(`\s*\bsd\b\s*`),
-	regexp.MustCompile(`\s*\bfull hd\b\s*`),
-	regexp.MustCompile(`\s*\b4k\b\s*`),
-	regexp.MustCompile(`\s*\buhd\b\s*`),
-	regexp.MustCompile(`\s*\buhd tv\b\s*`),
-}
+
 
 // DownloadM3U downloads an M3U playlist from url with a 100 MB size limit.
 func DownloadM3U(url string) (string, error) {
@@ -176,8 +167,8 @@ func FilterContent(content string, categoriesToRemove, channelNamesToExclude []s
 	}
 
 	contentNoDups := RemoveDuplicateURLs(strings.Join(filteredLines, "\n"))
-	processed := RemoveDuplicatesAndApplyHDPref(contentNoDups)
-	processed = SortPlaylistAlphabetically(processed)
+	processed := SortPlaylistAlphabetically(contentNoDups)
+	processed = AddSequentialNumbers(processed)
 	origCh := CountChannels(content)
 	procCh := CountChannels(processed)
 	logger.Info("Filtering complete: %d channels -> %d channels", origCh, procCh)
@@ -227,15 +218,6 @@ func ParseChannelEntries(lines []string) ([]string, []ChannelEntry) {
 		}
 	}
 	return headers, entries
-}
-
-// NormalizeNameForComparison strips HD/orig/SD/4K/UHD/FHD suffixes for deduplication matching.
-func NormalizeNameForComparison(name string) string {
-	normalized := strings.ToLower(name)
-	for _, re := range suffixesToRemove {
-		normalized = re.ReplaceAllString(normalized, " ")
-	}
-	return strings.Join(strings.Fields(normalized), " ")
 }
 
 // ParseCategoriesFile reads categories.txt and returns a map of lowercase channel name → {group, tvg_id}.
@@ -491,45 +473,41 @@ func AddTvgIDsToPlaylist(content string, epgNameToIDMap map[string]string) strin
 	return strings.Join(lines, "\n")
 }
 
-func RemoveDuplicatesAndApplyHDPref(content string) string {
+// toSuperscript converts an integer to superscript digits (¹, ², ³, ...).
+func toSuperscript(n int) string {
+	if n < 1 {
+		return ""
+	}
+	supers := []rune{'⁰', '¹', '²', '³', '⁴', '⁵', '⁶', '⁷', '⁸', '⁹'}
+	s := fmt.Sprintf("%d", n)
+	result := make([]rune, len(s))
+	for i, ch := range s {
+		result[i] = supers[ch-'0']
+	}
+	return string(result)
+}
+
+// AddSequentialNumbers adds a sequential superscript number (¹, ², ³, ...) to every channel name
+// based on its position in the sorted playlist.
+func AddSequentialNumbers(content string) string {
 	lines := strings.Split(content, "\n")
 	headers, entries := ParseChannelEntries(lines)
 
-	grouped := make(map[string][]ChannelEntry)
-
-	for _, entry := range entries {
+	for i, entry := range entries {
 		parts := strings.SplitN(entry.EXTINFLine, ",", 2)
-		var channelName string
 		if len(parts) > 1 {
-			channelName = strings.TrimSpace(parts[1])
-		}
-		normalizedName := NormalizeNameForComparison(channelName)
-		grouped[normalizedName] = append(grouped[normalizedName], entry)
-	}
-
-	var result []ChannelEntry
-	for key, variants := range grouped {
-		if len(variants) > 1 {
-			for idx, v := range variants {
-				parts := strings.SplitN(v.EXTINFLine, ",", 2)
-				if len(parts) > 1 {
-					chName := strings.TrimSpace(parts[1])
-					newName := fmt.Sprintf("%s #%d", chName, idx+1)
-					v.EXTINFLine = parts[0] + "," + newName
-				}
-				result = append(result, v)
-			}
-			logger.Info("Kept all %d variants for '%s' with numeric suffixes", len(variants), key)
-		} else {
-			result = append(result, variants...)
+			chName := strings.TrimSpace(parts[1])
+			newName := fmt.Sprintf("%s %s", chName, toSuperscript(i+1))
+			entries[i].EXTINFLine = parts[0] + "," + newName
 		}
 	}
 
 	var finalLines []string
 	finalLines = append(finalLines, headers...)
-	for _, entry := range result {
+	for _, entry := range entries {
 		finalLines = append(finalLines, entry.EXTINFLine)
 		finalLines = append(finalLines, entry.ExtraLines...)
 	}
 	return strings.Join(finalLines, "\n")
 }
+


### PR DESCRIPTION
## Описание

Сквозная надстрочная нумерация всех каналов в M3U-плейлисте.

### Изменения

- **Новая функция** `AddSequentialNumbers` — добавляет всем каналам надстрочный номер (1, 2, 3 ... N) по порядку
- **Новая функция** `toSuperscript` — конвертирует число в надстрочные Unicode-цифры
- **Новый порядок**: dedup по URL, сортировка A-Z, сквозная нумерация
- **Удалён мёртвый код**: `suffixesToRemove`, `NormalizeNameForComparison`, `RemoveDuplicatesAndApplyHDPref`
- **Обновлены тесты** под новую логику

### Затрагиваемые файлы
- `internal/m3u/processor.go`
- `internal/m3u/m3u_test.go`

Closes #69