### PR TITLE
feat: URL-based emoji pairs + cleanup excluded categories

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -158,8 +158,7 @@ var CategoriesToRemove = []string{
 	"𝕄𝕦𝕤𝕚𝕔",           // после нормализации
 	"45.𝕄𝕦𝕤𝕚𝕔 🇪🇺",
 	"𝕄𝕦𝕤𝕚𝕔",           // после нормализации
-	"45.145.32 🍟",
-	"145.32",            // после нормализации
+
 	// Служебные / Тестовые (bold unicode)
 	"56.𝕋𝕧ℤ𝕒𝕋𝕒𝕜 📼",
 	"𝕋𝕧ℤ𝕒𝕋𝕒𝕜",         // после нормализации
@@ -168,11 +167,7 @@ var CategoriesToRemove = []string{
 	"TVS ☆",
 	"TVS",               // после нормализации
 	"TvZaTak",
-	// Bold unicode кино (содержат символы, не покрываемые substring "кино")
-	"15.𝐊𝐢𝐧𝐨 📽",
-	"𝐊𝐢𝐧𝐨",            // после нормализации
-	"20.𝕂иℍ𝕠 🇷🇺",
-	"𝕂иℍ𝕠",            // после нормализации
+
 	"MavTV ⭐️",
 	"aleks-u-romki* 😊",
 }
@@ -180,10 +175,7 @@ var CategoriesToRemove = []string{
 // CategoriesToRemoveSubstring lists substrings to match against group-title (case-insensitive).
 // Any category whose name contains one of these substrings will be filtered out.
 var CategoriesToRemoveSubstring = []string{
-	// Кино и Сериалы
-	"кино", "сериал", "кинозал", "bcu", "kinowalk",
-	"гранд", "девяностые", "криминальная", "уральские",
-	"mav tv",
+
 	// Спорт (обычный текст)
 	"спорт", "sport", "матч",
 	// Спорт (bold unicode: ℂп𝕠𝕡т)
@@ -194,7 +186,7 @@ var CategoriesToRemoveSubstring = []string{
 	"радио тв", "музык", "dance", "retro", "bridge",
 	"trace", "mtv", "record", "dfm",
 	// Музыка (bold unicode: 𝕄𝕦𝕤𝕚𝕔, 145.32)
-	"𝕤𝕚𝕔", "145.32",
+	"𝕤𝕚𝕔",
 	// Религия
 	"религи",
 	// Relax
@@ -204,8 +196,8 @@ var CategoriesToRemoveSubstring = []string{
 	// АнтиРоссия / Украина
 	"антиросс", "україн", "украина", "наш нет",
 	// Служебные / Тестовые
-	"test", "rutube", "cinerama", "watcher", "flussonic",
-	"ngenix", "izone", "internet42", "onair", "ushba", "sewv",
+	"rutube", "cinerama", "watcher", "flussonic",
+	"ngenix", "internet42", "ushba", "sewv",
 	"tvz", "tv s", "tvzotak", "mavtv", "aleks",
 	// Служебные (bold unicode: 𝕋𝕧ℤ𝕒𝕋𝕒𝕜)
 	"𝕋𝕧ℤ",

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -100,8 +100,7 @@ func TestCategoriesToRemove(t *testing.T) {
 		"𝕄𝕦𝕤𝕚𝕔",
 		"45.𝕄𝕦𝕤𝕚𝕔 🇪🇺",
 		"𝕄𝕦𝕤𝕚𝕔",
-		"45.145.32 🍟",
-		"145.32",
+
 		"56.𝕋𝕧ℤ𝕒𝕋𝕒𝕜 📼",
 		"𝕋𝕧ℤ𝕒𝕋𝕒𝕜",
 		"62.32 📼",
@@ -109,10 +108,6 @@ func TestCategoriesToRemove(t *testing.T) {
 		"TVS ☆",
 		"TVS",
 		"TvZaTak",
-		"15.𝐊𝐢𝐧𝐨 📽",
-		"𝐊𝐢𝐧𝐨",
-		"20.𝕂иℍ𝕠 🇷🇺",
-		"𝕂иℍ𝕠",
 		"MavTV ⭐️",
 		"aleks-u-romki* 😊",
 	}

--- a/internal/m3u/m3u_test.go
+++ b/internal/m3u/m3u_test.go
@@ -218,39 +218,98 @@ http://example.com/same.m3u8`,
 	}
 }
 
-func TestAddSequentialNumbers(t *testing.T) {
-	content := `#EXTM3U
-#EXTINF:-1 tvg-id="711",Channel A
-http://example.com/a
-#EXTINF:-1 tvg-id="162",Channel B
-http://example.com/b
-#EXTINF:-1 tvg-id="711",Channel A
-http://example.com/a2
-#EXTINF:-1 tvg-id="999",Channel C
-http://example.com/c`
-
-	result := AddSequentialNumbers(content)
-
+func TestAddEmojiByURL(t *testing.T) {
 	tests := []struct {
-		name     string
-		original string
-		renamed  string
+		name    string
+		content string
+		checks  []string // channels that should be present
 	}{
-		{"channel 1", "Channel A", "Channel A ¹"},
-		{"channel 2", "Channel B", "Channel B ²"},
-		{"channel 3", "Channel A", "Channel A ³"},
-		{"channel 4", "Channel C", "Channel C ⁴"},
+		{
+			name: "deterministic: same URL → same emoji pair",
+			content: `#EXTM3U
+#EXTINF:-1 tvg-id="711",Channel A
+http://example.com/a.m3u8
+#EXTINF:-1 tvg-id="162",Channel B
+http://example.com/b.m3u8
+#EXTINF:-1 tvg-id="711",Channel A
+http://example.com/a.m3u8`,
+			checks: []string{"Channel A", "Channel B"},
+		},
+		{
+			name: "emoji pair appended to channel name",
+			content: `#EXTM3U
+#EXTINF:-1 tvg-id="100",Channel X
+http://example.com/x.m3u8
+#EXTINF:-1 tvg-id="200",Channel Y
+http://example.com/y.m3u8`,
+			checks: []string{"Channel X", "Channel Y"},
+		},
+		{
+			name: "handles different URLs producing different emojis",
+			content: `#EXTM3U
+#EXTINF:-1,Channel 1
+http://example.com/1.m3u8
+#EXTINF:-1,Channel 2
+http://example.com/2.m3u8
+#EXTINF:-1,Channel 3
+http://example.com/3.m3u8`,
+			checks: []string{"Channel 1", "Channel 2", "Channel 3"},
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			if strings.Contains(result, tc.original+",") {
-				t.Errorf("expected original name %q to be renamed to %q", tc.original, tc.renamed)
+			result := AddEmojiByURL(tc.content)
+
+			for _, ch := range tc.checks {
+				if !strings.Contains(result, ch) {
+					t.Errorf("expected '%s' to be present in result", ch)
+				}
 			}
-			if !strings.Contains(result, tc.renamed) {
-				t.Errorf("expected renamed channel %q in result", tc.renamed)
+
+			// Verify that original channel names without emoji no longer appear at the end of EXTINF.
+			for _, line := range strings.Split(result, "\n") {
+				if !strings.HasPrefix(strings.TrimSpace(line), "#EXTINF:") {
+					continue
+				}
+				parts := strings.SplitN(line, ",", 2)
+				if len(parts) < 2 {
+					continue
+				}
+				name := strings.TrimSpace(parts[1])
+				// Name should have an emoji appended (separated by space).
+				if !strings.Contains(name, " ") {
+					t.Errorf("expected emoji pair appended to channel name, got: %q", name)
+				}
 			}
 		})
+	}
+}
+
+func TestUrlToEmojiPairDeterministic(t *testing.T) {
+	url1a := "http://example.com/stream1.m3u8"
+	url1b := "http://example.com/stream1.m3u8"
+	url2 := "http://example.com/stream2.m3u8"
+
+	emoji1a := urlToEmojiPair(url1a)
+	emoji1b := urlToEmojiPair(url1b)
+	emoji2 := urlToEmojiPair(url2)
+
+	// Same URL → same emoji.
+	if emoji1a != emoji1b {
+		t.Errorf("same URL should produce same emoji pair: %q vs %q", emoji1a, emoji1b)
+	}
+
+	// Different URL → different emoji (highly likely).
+	// Not guaranteed but extremely improbable with 1600+ combinations.
+	if emoji1a == emoji2 {
+		t.Logf("note: different URLs produced same emoji pair %q (possible but unlikely)", emoji1a)
+	}
+
+	// Emoji pair should contain at least 2 non-ASCII characters (visual emojis).
+	// Note: some emojis like ☀️ use variation selectors (U+FE0F), so rune count may be >2.
+	if len(emoji1a) < 4 {
+		t.Errorf("expected emoji pair to have at least 4 bytes, got %d: %q", len(emoji1a), emoji1a)
 	}
 }
 

--- a/internal/m3u/processor.go
+++ b/internal/m3u/processor.go
@@ -2,6 +2,7 @@ package m3u
 
 import (
 	"fmt"
+	"hash/fnv"
 	"os"
 	"regexp"
 	"sort"
@@ -255,7 +256,7 @@ func FilterContent(content string, categoriesToRemove, categoriesToRemoveSubstri
 
 	contentNoDups := RemoveDuplicateURLs(strings.Join(filteredLines, "\n"))
 	processed := SortPlaylistAlphabetically(contentNoDups)
-	processed = AddSequentialNumbers(processed)
+	processed = AddEmojiByURL(processed)
 	origCh := CountChannels(content)
 	procCh := CountChannels(processed)
 	logger.Info("Filtering complete: %d channels -> %d channels", origCh, procCh)
@@ -560,31 +561,59 @@ func AddTvgIDsToPlaylist(content string, epgNameToIDMap map[string]string) strin
 	return strings.Join(lines, "\n")
 }
 
-// toSuperscript converts an integer to superscript digits (¹, ², ³, ...).
-func toSuperscript(n int) string {
-	if n < 1 {
-		return ""
-	}
-	supers := []rune{'⁰', '¹', '²', '³', '⁴', '⁵', '⁶', '⁷', '⁸', '⁹'}
-	s := fmt.Sprintf("%d", n)
-	result := make([]rune, len(s))
-	for i, ch := range s {
-		result[i] = supers[ch-'0']
-	}
-	return string(result)
+// emojiPoolA are visually distinct shape/color/symbol emojis used as the first component
+// of the emoji pair identifier. The pair provides ~1500+ unique combinations.
+var emojiPoolA = []string{
+	"🔴", "🟠", "🟡", "🟢", "🔵", "🟣", "⚫", "⚪",
+	"🔶", "🔷", "🔸", "🔹", "🔺", "🔻", "⬛", "⬜",
+	"🔘", "⭕", "💠", "💮", "❓", "💢", "💥", "💫",
+	"🌟", "⭐", "✨", "🔥", "💧", "🌊", "☀️", "🌙",
+	"☁️", "⚡", "🌀", "🌈", "💨", "❄️", "🌪", "🌫",
 }
 
-// AddSequentialNumbers adds a sequential superscript number (¹, ², ³, ...) to every channel name
-// based on its position in the sorted playlist.
-func AddSequentialNumbers(content string) string {
+// emojiPoolB are visually distinct object/animal/nature emojis used as the second component.
+var emojiPoolB = []string{
+	"🐶", "🐱", "🐼", "🐯", "🦁", "🦊", "🐻", "🐨",
+	"🐰", "🦄", "🐸", "🐵", "🦋", "🐝", "🐞", "🐌",
+	"🌻", "🌺", "🌹", "🌸", "🌴", "🍀", "🌿", "🍁",
+	"🎯", "🏆", "🎮", "🎸", "🎺", "🎻", "🥁", "📺",
+	"🎬", "🎵", "🎶", "🚀", "🛸", "🎪", "🎭", "🎨",
+}
+
+// urlToEmojiPair generates a deterministic emoji pair (from two pools) based on the URL hash.
+// Same URL always produces the same emoji pair. Uses FNV-1a 64-bit hash for speed and distribution.
+func urlToEmojiPair(url string) string {
+	h := fnv.New64a()
+	h.Write([]byte(url))
+	sum := h.Sum64()
+	a := emojiPoolA[sum%uint64(len(emojiPoolA))]
+	b := emojiPoolB[(sum>>32)%uint64(len(emojiPoolB))]
+	return a + b
+}
+
+// AddEmojiByURL adds a unique emoji pair (e.g. 🔴🐱) to every channel name,
+// deterministically derived from the channel's stream URL via FNV-1a hash.
+// This replaces the previous sequential superscript numbering.
+func AddEmojiByURL(content string) string {
 	lines := strings.Split(content, "\n")
 	headers, entries := ParseChannelEntries(lines)
 
 	for i, entry := range entries {
+		// Extract URL from ExtraLines.
+		url := ""
+		for _, extraLine := range entry.ExtraLines {
+			trimmed := strings.TrimSpace(extraLine)
+			if strings.HasPrefix(trimmed, "http") {
+				url = trimmed
+				break
+			}
+		}
+
 		parts := strings.SplitN(entry.EXTINFLine, ",", 2)
 		if len(parts) > 1 {
 			chName := strings.TrimSpace(parts[1])
-			newName := fmt.Sprintf("%s %s", chName, toSuperscript(i+1))
+			emoji := urlToEmojiPair(url)
+			newName := fmt.Sprintf("%s %s", chName, emoji)
 			entries[i].EXTINFLine = parts[0] + "," + newName
 		}
 	}


### PR DESCRIPTION
Closes #74

## Changes

### URL-based emoji pairs
- Replaced sequential superscript numbering (¹²³) with unique emoji pairs
- Each channel gets a deterministic emoji pair from its stream URL via FNV-1a 64-bit hash
- Two curated pools (40 symbols + 40 objects) provide ~1600 unique combinations
- Same URL → always same emoji pair

### Config cleanup
- Removed кино, izone, onair, test, 145.32 from category exclusion lists
- Updated config_test.go accordingly

### Testing
- Full test suite: PASS
- Dry-run: 10,466 → 5,010 channels, emoji pairs verified