### PR TITLE
feat: exclude bold кино, РОССИЯ+ and regular Кино categories

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -170,6 +170,13 @@ var CategoriesToRemove = []string{
 
 	"MavTV ⭐️",
 	"aleks-u-romki* 😊",
+
+	// Кино и сериалы (bold unicode)
+	"𝐊𝐢𝐧𝐨",
+	"𝕂иℍ𝕠",
+
+	// Региональные категории
+	"РОССИЯ+",
 }
 
 // CategoriesToRemoveSubstring lists substrings to match against group-title (case-insensitive).
@@ -229,7 +236,7 @@ var CategoriesToRemoveSubstring = []string{
 	"швейцари", "шри-ланка",
 	"эквадор", "эфиопи", "япони",
 // Кино / Сериалы / Шоу (исключаемые категории)
-	"девяностые", "кинозал", "киноstream",
+	"кино", "девяностые", "кинозал", "киноstream",
 	"сериал", "криминальная", "kinowalk",
 	"екб", "kino", "viju",
 	"тайны", "уральские",

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -110,6 +110,11 @@ func TestCategoriesToRemove(t *testing.T) {
 		"TvZaTak",
 		"MavTV ⭐️",
 		"aleks-u-romki* 😊",
+
+		"𝐊𝐢𝐧𝐨",
+		"𝕂иℍ𝕠",
+
+		"РОССИЯ+",
 	}
 	if len(CategoriesToRemove) != len(expected) {
 		t.Errorf("expected %d categories, got %d", len(expected), len(CategoriesToRemove))


### PR DESCRIPTION
## Changes

- Added `𝐊𝐢𝐧𝐨`, `𝕂иℍ𝕠`, `РОССИЯ+` to `CategoriesToRemove` (exact match)
- Added `кино` back to `CategoriesToRemoveSubstring` (substring match)
- Updated `config_test.go` accordingly

## Testing
- Dry-run verified: 10,466 → 3,181 channels
- Кино (434), РОССИЯ+ (235), 𝐊𝐢𝐧𝐨 (109), 𝕂иℍ𝕠 (46) — all filtered out