### PR TITLE
feat: architecture improvements — context propagation, config caching, streaming EPG, graceful shutdown

### DIFF
--- a/.github/workflows/filter-m3u.yml
+++ b/.github/workflows/filter-m3u.yml
@@ -25,7 +25,7 @@ env:
 jobs:
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     permissions:
       contents: read
 
@@ -41,12 +41,18 @@ jobs:
         go-version: '1.25'
         cache: true
 
+    - name: Build
+      run: go build -o /dev/null ./...
+
+    - name: Vet
+      run: go vet ./...
+
     - name: Run tests
       run: go test ./... -v -count=1
 
   filter-m3u:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 30
     needs: test
     if: github.event_name != 'pull_request' || always()
     permissions:
@@ -64,9 +70,20 @@ jobs:
         go-version: '1.25'
         cache: true
 
+    - name: Build binary
+      run: go build -o iptv-filter ./cmd/iptv-filter/
+
     - name: Set dry-run mode for pull requests
       if: github.event_name == 'pull_request'
       run: echo "DRY_RUN=true" >> $GITHUB_ENV
 
     - name: Run M3U filter script
-      run: go run ./cmd/iptv-filter/
+      run: ./iptv-filter
+
+    - name: Upload output artifacts
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: output
+        path: output/
+        retention-days: 7

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,53 +2,65 @@
 
 ## Project
 
-IPTV M3U playlist filter: downloads M3U from HTTP URLs, filters by category (deny-list), normalizes names (remove `orig`, exclude regional `+1`/`+4` variants), numbers all channels sequentially with superscript (¹, ², ³ … ⁿ), optionally processes EPG, uploads to S3-compatible storage (Yandex Cloud).
+IPTV M3U playlist filter: downloads M3U from HTTP URLs, filters by category (deny-list), normalizes names (remove `orig`, exclude regional `+N` variants), assigns unique emoji pairs to channels deterministically derived from stream URL via FNV-1a hash, optionally processes EPG, uploads to S3-compatible storage (Yandex Cloud).
 
 ## Language & runtime
 
-Rewritten from Python to Go. Runs via `go run ./cmd/iptv-filter/` — no binary build needed.
+Rewritten from Python to Go. Go 1.25+.
 
 ## Entry points
 
 - `cmd/iptv-filter/main.go` — script entry point
 - `go run ./cmd/iptv-filter/` — run directly (compiles to temp, executes)
+- `make build` → `./bin/iptv-filter` (binary also available)
 
 ## Commands
 
 ```bash
 go test ./... -v -count=1           # run all tests
-go run ./cmd/iptv-filter/           # run (requires .env or export vars)
-DRY_RUN=true go run ./cmd/iptv-filter/  # dry-run (no S3 upload)
+go vet ./...                        # run vet
+make build                          # build binary (bin/iptv-filter)
+make run                            # go run (requires .env or export vars)
+DRY_RUN=true make run               # dry-run (no S3 upload)
+make clean                          # rm -rf output/ bin/
 ```
 
 ## Development conventions
 
 - Go standard project layout (`cmd/`, `internal/`)
-- AWS SDK v2 for S3 operations
-- Standard library `net/http` for HTTP (with `InsecureSkipVerify: true` for local dev)
-- `encoding/xml` for EPG XML parsing
+- AWS SDK v2 for S3 operations (client-based, reusable `*s3.Client`)
+- Standard library `net/http` for HTTP (configurable SSL via `SKIP_SSL_VERIFY` env var)
+- `encoding/xml` for EPG XML parsing (streaming `xml.Decoder` for 463MB+ XML)
 - `compress/gzip` and `archive/zip` for compression
-- Environment-based config via `internal/config/` (stateless, reads env vars)
-- Sanitized logging via `internal/utils/logger.go` (masks URLs and credentials)
+- Environment-based config via `internal/config/` (cached in struct on `New()`)
+- Context propagation throughout: graceful shutdown on SIGINT/SIGTERM
+- Sanitized logging via `internal/utils/logger.go` (masks URLs + AWS/Yandex keys)
 
 ## Architecture
 
 ```
 iptv/
-├── cmd/iptv-filter/main.go        # Entry point (go run)
+├── cmd/iptv-filter/main.go        # Entry point (pipeline: download→filter→EPG→upload)
 ├── internal/
-│   ├── config/config.go           # Configuration from env vars with validation
-│   ├── m3u/processor.go           # M3U download, filtering, normalization
-│   ├── epg/processor.go           # EPG download (gzip/zip), XML filtering
-│   ├── s3/upload.go               # S3 upload via AWS SDK v2
+│   ├── config/config.go           # Cached config from env vars with validation
+│   ├── config/config_test.go      # Tests + filter list assertions
+│   ├── m3u/processor.go           # M3U download, filtering, normalization pipeline
+│   ├── m3u/m3u_test.go            # Unit tests for all M3U functions
+│   ├── epg/processor.go           # EPG download, streaming XML filtering
+│   ├── epg/epg_test.go            # EPG filter tests
+│   ├── s3/upload.go               # S3 upload via AWS SDK v2 (reusable client)
+│   ├── s3/s3_test.go              # S3 endpoint/credential tests
 │   └── utils/
-│       ├── http.go                # Shared HTTP client and DownloadFile utility
-│       ├── logger.go              # Sanitized logger
+│       ├── http.go                # HTTP client (context-aware, configurable SSL)
+│       ├── logger.go              # Sanitized logger (masks credentials)
+│       ├── helper.go              # ToLowerSlice, NormalizeLineEndings
 │       ├── retry.go               # Retry with exponential backoff
-│       └── compress.go            # GZip/ZIP decompression utilities
-├── .github/workflows/filter-m3u.yml
+│       ├── compress.go            # GZip/ZIP decompression utilities
+│       └── utils_test.go          # Retry + sanitization tests
+├── .github/workflows/filter-m3u.yml  # CI: test+build → filter → artifacts
 ├── go.mod / go.sum
-├── categories.txt                 # Channel metadata (group-title/tvg-id overrides)
+├── categories.txt                 # Channel metadata (group-title/tvg-id/tvg-rec overrides)
+├── AGENTS.md                      # This file
 └── README.md
 ```
 
@@ -56,101 +68,167 @@ iptv/
 
 ### internal/config/config.go
 
-Config struct reading env vars with validation. Includes:
-- `CategoriesToRemove` — deny-list of categories (exact match, case-insensitive). Contains 46 entries covering: adult/18+, religion, anti-Russia, Ukraine, bold-unicode sport/music/TV, test/service categories with both original (numbered/emojis) and normalized (cleaned) variants.
-- `CategoriesToRemoveSubstring` — deny-list of ~130 substrings (case-insensitive). Any category whose name contains one of these substrings is filtered out. Covers: movies/series, sports (regular + bold unicode), kids, music (regular + bold unicode), religion, relax, fashion/shopping, anti-Russia/Ukraine, test/service, countries/regions (60+ countries), TV shows.
-- `ChannelNamesToExclude` — channels to exclude by name substring
-- `EPGExcludedCategories` / `EPGExcludedChannelIDs`
-- `DryRun()` — returns true if `DRY_RUN` env var is set to a truthy value
-- `BuildCustomEPGURL()` — constructs public URL for EPG file in S3
-- `OutputDir()` — returns local output directory (default: `output/`)
-- `Validate()` — validates all required env vars before processing
+**Config struct** — all env vars read ONCE in `New()` and cached for fast access:
+
+| Method | Env var | Default |
+|--------|---------|---------|
+| `M3USourceURL()` | `M3U_SOURCE_URL` | — |
+| `S3DefaultBucketName()` | `S3_BUCKET_NAME` | — |
+| `S3FilteredPlaylistKey()` | `S3_OBJECT_KEY` | `playlist.m3u` |
+| `S3AllCategoriesPlaylistKey()` | — | `playlist-all.m3u` |
+| `S3EndpointURL()` | `S3_ENDPOINT_URL` | — |
+| `S3Region()` | `S3_REGION` | `us-east-1` |
+| `EPGSourceURL()` | `EPG_SOURCE_URL` | — |
+| `S3EPGKey()` | `S3_EPG_KEY` | — |
+| `EPGRetentionDays()` | `EPG_RETENTION_DAYS` | `10` |
+| `OutputDir()` | `OUTPUT_DIR` | `output` |
+| `CategoriesFilePath()` | `CATEGORIES_FILE_PATH` | — |
+| `DryRun()` | `DRY_RUN` | `false` |
+| `SkipSSLVerify()` | `SKIP_SSL_VERIFY` | `false` |
+| `EnsureOutputDir()` | — | creates output dir via `os.MkdirAll` |
+
+**Filter lists** (package-level vars):
+
+- `CategoriesToRemove` — deny-list for exact category match (26 entries, case-insensitive). After dedup, only **normalized** variants remain — the normalization step strips leading numbers and trailing emojis before matching.
+  - Adult/18+, Religion, Support/INFO
+  - Anti-Russia/Ukraine (АнтиРОССИЙСКИЕ, 𝕐𝕜𝕡𝕒Їℍ𝕒, Українські, Украина, Наш Нет)
+  - Sport (bold unicode: ℂп𝕠𝕡т, 186)
+  - Music (bold unicode: РАДИО ТВ, 𝕄𝕦𝕤𝕚𝕔)
+  - Service/Test (bold unicode: 𝕋𝕧ℤ𝕒𝕋𝕒𝕜, 32, TVS, TvZaTak, MavTV, aleks-u-romki*)
+  - Cinema (bold unicode: 𝐊𝐢𝐧𝐨, 𝕂иℍ𝕠)
+  - Regional: РОССИЯ+
+- `CategoriesToRemoveSubstring` — ~100 substrings matched against group-title. Covers: sport, kids, music, religion, relax, fashion, anti-Russia/Ukraine, service/test, countries/regions (~60), cinema/series, specific TV shows
+- `ChannelNamesToExclude` — channel names excluded by substring (Fashion, СПАС, Три ангела, ЛДПР, UA, Sports)
+- `EPGExcludedCategories` — EPG categories excluded (default: `Кино`)
+- `EPGExcludedChannelIDs` — 31 specific EPG channel IDs excluded
+- `Validate()` — validates all required env vars, URL format, bucket/key length
 
 ### internal/m3u/processor.go
 
-M3U download, filtering, parsing, normalization. Key functions:
-- `DownloadM3U()` — HTTP download with size check (100MB)
-- `FilterContent()` — line-by-line filter: category deny-list, channel name exclusion, regional `+N` exclusion, number suffix exclusion, `orig` removal
+**M3U pipeline** (extracted into small functions for testability):
+
+```
+DownloadM3U → FilterContent (NormalizeLineEndings → filterEntry → dedup → sort → emoji)
+```
+
+Key exported functions:
+- `DownloadM3U(url)` / `DownloadM3UWithContext(ctx, url, skipSSL)` — HTTP download with 100MB size limit
+- `FilterContent()` — main pipeline: normalization, category filtering (exact + substring), name exclusion, regional suffix removal, numeric suffix removal, `orig` removal, dedup, sort, emoji
+- `RemoveDuplicateURLs()` — deduplicates by URL, merges attributes (tvg-id, group-title, tvg-logo, tvg-rec), keeps longest name
+- `SortPlaylistAlphabetically()` — A-Z by channel name (case-insensitive, stable sort)
+- `AddEmojiByURL()` — appends FNV-1a based emoji pair (🔴🐱) to each channel name; 40×40 pools = ~1600 combinations
+- `AddTvgIDsToPlaylist()` — adds `tvg-id` from EPG name-to-id map
 - `RemoveOrigSuffix()` — strips trailing " orig"
-- `RemoveDuplicateURLs()` — deduplicates entries with identical URLs, merges attributes (tvg-id, group-title, tvg-logo, tvg-rec), keeps the longest channel name
-- `SortPlaylistAlphabetically()` — sorts playlist entries A-Z by channel name (case-insensitive)
-- `AddSequentialNumbers()` — adds sequential superscript number (¹, ², ³ … ⁿ) to every channel after sorting
-- `ParseCategoriesFile()` — parses categories.txt for metadata overrides
-- `ApplyChannelMetadata()` — overrides group-title/tvg-id from categories.txt
-- `AddTvgIDsToPlaylist()` — adds tvg-id from EPG name-to-id map
-- `CountChannels()` — counts #EXTINF entries in M3U content
+- `ParseCategoriesFile()` / `ApplyChannelMetadata()` — categories.txt override
+- `CountChannels()` — counts #EXTINF entries
+
+Filtering steps per entry:
+1. Extract `group-title`, normalize it (strip leading numbers + trailing emojis)
+2. Check exact match against `CategoriesToRemove` (case-insensitive)
+3. Check substring match against `CategoriesToRemoveSubstring` (case-insensitive)
+4. Check channel name against `ChannelNamesToExclude` (substring, case-insensitive)
+5. Check for regional suffix (`+N`, `+N HD`, `+N (region)`)
+6. Check for numeric suffix (`HD 50`, `Channel 25`)
+7. Strip `orig` suffix
 
 ### internal/epg/processor.go
 
-EPG download and XML filtering. Key functions:
-- `DownloadEPG()` — downloads with gzip/zip decompression, 500MB limit
-- `ExtractChannelInfoFromPlaylist()` — extracts tvg-ids and channel names from M3U
-- `BuildEPGNameToIDMap()` — builds lowercase display-name → channel-id map from EPG XML
-- `FilterEPGContent()` — filters EPG by channel IDs/names, excludes categories/IDs, time-based retention
-- `SaveFilteredEPGLocally()` — saves with gzip compression
+**EPG processing** (streaming XML parser, single-pass):
+
+- `DownloadEPG(ctx, url, cfg)` — downloads with gzip/zip decompression, 500MB limit, context-aware
+- `ExtractChannelInfoFromPlaylist()` — extracts `tvg-id` → category and channel name → category from M3U
+- `BuildEPGNameToIDMap()` — builds lowercase display-name → channel-id map via `xml.Unmarshal` (small struct)
+- `FilterEPGContent()` — **single-pass streaming** `xml.Decoder` parsing:
+  - Pre-computes retention window (`time.Now()` once, not per programme)
+  - First pass: builds EPG channel display-name map
+  - Second pass eliminated (merged into one pass — channels come before programmes in XMLTV)
+  - Filters channels by ID/name matching
+  - Applies category exclusions and channel ID exclusions
+  - Applies time-based retention (default 10 days)
+  - Returns filtered XML with `xml.MarshalIndent`
+- `SaveFilteredEPGLocally()` — saves with gzip compression if filename ends with `.gz`
 
 ### internal/s3/upload.go
 
-S3 upload via AWS SDK v2. Functions:
-- `UploadToS3()` — string content → S3
-- `UploadFileToS3()` — local file → S3 (with output dir fallback)
-- `UploadArchiveToS3()` — gzip-compressed → archive/YYYY-MM-DD/HH-MM-SS-UUID_key.gz
+**S3 upload** (client-based API, reusable `*s3.Client`):
+
+- `NewClient(ctx, endpoint, region)` — creates reusable S3 client (validates endpoint)
+- `UploadToS3(ctx, client, content, bucket, key, contentType)` — string → S3
+- `UploadFileToS3(ctx, client, filePath, bucket, key, outputDir, contentType)` — local file → S3 (with fallback to output dir)
+- `UploadArchiveToS3(ctx, client, content, bucket, baseKey)` — gzip-compressed → `archive/YYYY-MM-DD/HH-MM-SS-UUID_key.gz`
+- `UploadBoth(ctx, client, content, bucket, key, contentType)` — archive + direct upload
+- Default `Content-Type`: `application/x-mpegurl` for M3U, `application/gzip` for EPG
+- Metadata: `uploaded-by: iptv-m3u-filter`, `upload-timestamp`, `source-file`, size info
+- Nil-client guard: all functions return error if client is nil
 
 ### internal/utils/
 
-- `DownloadFile()` — shared HTTP download with size limit enforcement
-- `Retry()` — utility function with exponential backoff (3 attempts, 2s delay, 2x backoff)
-- `SanitizedWriter` — log wrapper that masks URLs and AWS keys in output
-- `IsGzipped()` / `DecompressGZip()` — detects and decompresses gzipped content
-- `DecompressZip()` — extracts `.zip` archives (first entry)
+- `DownloadFile(url, maxSize)` / `DownloadFileWithContext(ctx, url, maxSize, skipSSL)` — HTTP download with size limit
+- `NewHTTPClient(skipSSL)` — configurable SSL verification
+- `Retry(maxAttempts, delay, backoff, fn)` — exponential backoff (3 attempts, 2s, 2x)
+- `ToLowerSlice(slice)` — lowercase all strings in slice
+- `NormalizeLineEndings(content)` — `\r\n` → `\n`
+- `IsGzipped()` / `DecompressGZip()` / `DecompressZip()` — compression detection/helpers
+- `SanitizedWriter` — log wrapper masking: URLs → `https://****/****`, AWS/Yandex keys → `YCAJ****abcd` / `AKIA****xxxx`
 
 ## Filtering logic (internal/m3u/)
 
-- **Category filter**: deny-list approach — `CategoriesToRemove` (default: 8 categories: религия, adult/18+, поддержка проекта, info). Everything else is kept.
-- **Channel exclusions**: `ChannelNamesToExclude` — matched case-insensitively as substring (default: `Fashion`, `СПАС`, `Три ангела`, `ЛДПР`, `UA`, `Sports`)
-- **Regional exclusion**: channels ending with `+N` (e.g. `+1`, `+4 HD`, `+2 (Приволжье)`) are removed
-- **Number suffix exclusion**: channels ending with `2+` digits (e.g. `HD 50`, `50`) are removed — all channels excluded uniformly, no exemptions
-- **Name processing**: `orig` suffix removed from channel names
-- **Sequential numbering**: all channels are numbered sequentially with superscript digits (¹, ², ³ … ⁿ) after alphabetical sorting
-- **Optional metadata**: `categories.txt` can supply `group-title`/`tvg-id` overrides via `CATEGORIES_FILE_PATH` env var (matched by lowercase name)
-- **EPG-based tvg-id**: channels without `tvg-id` get one matched by name against EPG display-names
+- **Category filter**: deny-list approach — `CategoriesToRemove` (26 exact matches) + `CategoriesToRemoveSubstring` (~100 substrings)
+- **Group-title normalization**: leading numbers (`^\\d+.\\s*`) stripped, trailing emojis stripped
+- **Channel exclusions**: by name substring (6 patterns), regional suffix (`+N`), numeric suffix (`2+` digits at end)
+- **Name processing**: `orig` suffix removed
+- **Emoji identifiers**: FNV-1a 64-bit hash of stream URL → pair from 2×40 emoji pools, appended to channel name
+- **Dedup by URL**: first non-empty attributes merged, longest name wins
+- **Sort**: A-Z case-insensitive stable sort after dedup
+- **Metadata overrides**: `categories.txt` can supply `group-title`/`tvg-id` via `CATEGORIES_FILE_PATH` env var
 
 ## EPG processing (internal/epg/)
 
 - Downloads from `EPG_SOURCE_URL` (supports `.gz` and `.zip`)
 - `EPG_RETENTION_DAYS` (default: 10) — discards programmes outside this window
 - `EPGExcludedCategories` — categories excluded from EPG (default: `Кино`)
-- `EPGExcludedChannelIDs` — specific channel IDs excluded from EPG (30+ IDs)
+- `EPGExcludedChannelIDs` — 31 specific channel IDs
+- Filtering uses **single-pass streaming** `xml.Decoder` (no full 463MB `xml.Unmarshal`)
 - Output saved as `.gz` compressed
 
 ## S3 upload (internal/s3/)
 
-Uploads: filtered playlist, all-categories playlist, EPG file, plus `.gz` archives of the playlists.
-- `UploadToS3` — string content → S3
-- `UploadFileToS3` — local file → S3
-- `UploadArchiveToS3` — gzip-compressed content → S3
-- Uses `Retry` helper (3 attempts, exponential backoff)
-- Default content type: `application/x-mpegurl`
+Uploads: filtered playlist, all-categories playlist, EPG file, plus `.gz` archives.
+- Client created once via `NewClient()`; reused for all uploads
+- `UploadBoth` combines archive + direct upload in one call
+- Retry wrapper: 3 attempts, 2s delay, 2x backoff
 
 ## Security features
 
-- **Input Validation**: Validates URLs and config before processing
+- **Input Validation**: Validates URLs, bucket names, keys before processing
 - **Size Limiting**: 100MB for M3U, 500MB for EPG
-- **Log Sanitization**: Masks URLs (`https://****/****`) and AWS keys (`YCAJ****abcd`)
-- **Credential Handling**: Uses env vars for sensitive data
-- **SSL**: InsecureSkipVerify enabled for local dev
+- **Log Sanitization**: Masks URLs (`https://****/****`) and credentials:
+  - Yandex Cloud: `YCAJEu...` (key), `YCON...` (secret)
+  - AWS: `AKIA...`, `ASIA...` (access keys)
+- **Credential Handling**: Uses env vars for sensitive data, never logged
+- **SSL**: Configurable via `SKIP_SSL_VERIFY` (default: `false` — secure)
 
 ## CI (GitHub Actions)
 
-- **test job**: `go test ./... -v -count=1`
-- **filter-m3u job**: depends on test; runs `go run ./cmd/iptv-filter/`
+Two jobs in `.github/workflows/filter-m3u.yml`:
+
+**test** (timeout 10 min):
+- `go build`, `go vet`, `go test -v -count=1`
+
+**filter-m3u** (timeout 30 min, depends on test):
+- Builds binary: `go build -o iptv-filter`
+- Runs `./iptv-filter`
 - PRs get `DRY_RUN=true` set automatically
-- Secrets: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `M3U_SOURCE_URL`, `S3_BUCKET_NAME`, `S3_OBJECT_KEY`, `S3_ENDPOINT_URL`, `S3_REGION`, `S3_EPG_KEY`, `EPG_SOURCE_URL`, `LOCAL_EPG_PATH`
+- Uploads `output/` artifacts (retention: 7 days)
+
+Secrets: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `M3U_SOURCE_URL`, `S3_BUCKET_NAME`, `S3_OBJECT_KEY`, `S3_ENDPOINT_URL`, `S3_REGION`, `S3_EPG_KEY`, `EPG_SOURCE_URL`, `LOCAL_EPG_PATH`
 
 ## Environment quirks
 
 - `.env` file exists locally — `export $(grep -v '^#' .env | xargs)` to load
-- SSL cert verification disabled (`InsecureSkipVerify: true`) for URL downloads — intentional for local dev
+- `SKIP_SSL_VERIFY=true` for local dev (not set in CI)
 - `SanitizedWriter` wraps `log.Logger` and masks credentials in log output
-- `Retry` helper on download/upload functions (3 retries, 2s delay, 2x backoff)
+- `Retry` helper on all download/upload functions (3 retries, 2s delay, 2x backoff)
 - File size limits: 100 MB for M3U, 500 MB for EPG
+- Graceful shutdown on SIGINT/SIGTERM via `context.Context` cancellation
+- EPG streaming parser: single-pass `xml.Decoder`, pre-computed retention window, no dead code

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,12 @@
-.PHONY: test run dry-run vet lint clean
+.PHONY: test run dry-run vet lint clean build
 
 # Run all tests with verbose output
 test:
 	go test ./... -v -count=1
+
+# Build binary
+build:
+	go build -o bin/iptv-filter ./cmd/iptv-filter/
 
 # Run the M3U filter (requires .env or exported vars)
 run:
@@ -18,5 +22,5 @@ vet:
 
 # Clean output directory and temporary files
 clean:
-	rm -rf output/
+	rm -rf output/ bin/
 	rm -f playlist.m3u playlist-all.m3u

--- a/cmd/iptv-filter/main.go
+++ b/cmd/iptv-filter/main.go
@@ -9,6 +9,8 @@ import (
 	"syscall"
 	"time"
 
+	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
+
 	"github.com/ozyab/iptv/internal/config"
 	"github.com/ozyab/iptv/internal/epg"
 	"github.com/ozyab/iptv/internal/m3u"
@@ -31,14 +33,9 @@ func gracefulCtx() (context.Context, context.CancelFunc) {
 	return ctx, cancel
 }
 
-// saveFile writes M3U content to a file in the output directory.
+// saveFile writes content to a file in the output directory.
 func saveFile(content, filename string, cfg *config.Config) {
-	outputDir := cfg.OutputDir()
-	if err := os.MkdirAll(outputDir, 0755); err != nil {
-		log.Error("Failed to create output directory: %v", err)
-		return
-	}
-	filepath := path.Join(outputDir, filename)
+	filepath := path.Join(cfg.OutputDir(), filename)
 	if err := os.WriteFile(filepath, []byte(content), 0644); err != nil {
 		log.Error("Failed to save file: %v", err)
 		return
@@ -89,12 +86,12 @@ func parseM3USources(m3uURL string) []string {
 
 // ─── Pipeline step: download M3U ────────────────────────────────────────────────
 
-func downloadM3U(ctx context.Context, urlStr string) (string, error) {
+func downloadM3U(ctx context.Context, urlStr string, skipSSLVerify bool) (string, error) {
 	log.Info("Downloading M3U source: %s", urlStr)
 	var original string
 	err := utils.Retry(3, 2*time.Second, 2.0, func() error {
 		var e error
-		original, e = m3u.DownloadM3U(urlStr)
+		original, e = m3u.DownloadM3UWithContext(ctx, urlStr, skipSSLVerify)
 		return e
 	})
 	return original, err
@@ -127,7 +124,7 @@ func applyMetadata(content string, cfg *config.Config) string {
 
 // ─── Pipeline step: process EPG ──────────────────────────────────────────────────
 
-func processEPG(ctx context.Context, cfg *config.Config, epgURL string, filteredContent string, dryRun bool) (string, error) {
+func processEPG(ctx context.Context, cfg *config.Config, epgURL string, filteredContent string, s3Client *awss3.Client, dryRun bool) (string, error) {
 	log.Info("Starting EPG filtering process")
 
 	var epgContent string
@@ -139,12 +136,10 @@ func processEPG(ctx context.Context, cfg *config.Config, epgURL string, filtered
 		return filteredContent, err
 	}
 
-	// Build tvg-id map from EPG and add missing tvg-ids to filtered playlist.
 	epgNameToIDMap := epg.BuildEPGNameToIDMap(epgContent)
 	filteredContent = m3u.AddTvgIDsToPlaylist(filteredContent, epgNameToIDMap)
 	saveFile(filteredContent, cfg.LocalFilteredPlaylistPath(), cfg)
 
-	// Extract channel info and filter EPG programmes.
 	chIDs, chNames := epg.ExtractChannelInfoFromPlaylist(filteredContent)
 	filteredEPG, err := epg.FilterEPGContent(epgContent, chIDs, config.EPGExcludedCategories, config.EPGExcludedChannelIDs, chNames, cfg.EPGRetentionDays())
 	if err != nil {
@@ -153,10 +148,9 @@ func processEPG(ctx context.Context, cfg *config.Config, epgURL string, filtered
 
 	epg.SaveFilteredEPGLocally(filteredEPG, cfg.LocalFilteredEPGPath(), cfg)
 
-	// Upload filtered EPG to S3 (non-dry-run only).
-	if !dryRun {
+	if !dryRun && s3Client != nil {
 		uploadWithRetry(ctx, func() error {
-			return s3.UploadFileToS3(ctx, cfg.LocalFilteredEPGPath(), cfg.S3DefaultBucketName(), cfg.S3EPGKey(), cfg.OutputDir(), cfg.S3EndpointURL(), cfg.S3Region(), "application/gzip")
+			return s3.UploadFileToS3(ctx, s3Client, cfg.LocalFilteredEPGPath(), cfg.S3DefaultBucketName(), cfg.S3EPGKey(), cfg.OutputDir(), "application/gzip")
 		})
 	}
 
@@ -171,9 +165,9 @@ func uploadWithRetry(ctx context.Context, fn func() error) {
 	}
 }
 
-func uploadBoth(ctx context.Context, content, bucket, key, s3Endpoint, region string) {
+func uploadBoth(ctx context.Context, client *awss3.Client, content, bucket, key string) {
 	uploadWithRetry(ctx, func() error {
-		return s3.UploadBoth(ctx, content, bucket, key, s3Endpoint, region)
+		return s3.UploadBoth(ctx, client, content, bucket, key, "")
 	})
 }
 
@@ -192,6 +186,12 @@ func run() int {
 	ctx, cancel := gracefulCtx()
 	defer cancel()
 
+	// Ensure output directory exists once.
+	if err := cfg.EnsureOutputDir(); err != nil {
+		log.Error("Failed to create output directory: %v", err)
+		return 1
+	}
+
 	m3uURL := cfg.M3USourceURL()
 	epgURL := cfg.EPGSourceURL()
 	s3Bucket := cfg.S3DefaultBucketName()
@@ -200,6 +200,7 @@ func run() int {
 	dryRun := cfg.DryRun()
 	s3Endpoint := cfg.S3EndpointURL()
 	customEPGURL := cfg.BuildCustomEPGURL()
+	skipSSL := cfg.SkipSSLVerify()
 
 	m3uURLs := parseM3USources(m3uURL)
 	log.Info("Processing %d M3U source(s)", len(m3uURLs))
@@ -208,7 +209,7 @@ func run() int {
 	var allFiltered []string
 	var allOriginal []string
 	for _, urlStr := range m3uURLs {
-		original, err := downloadM3U(ctx, urlStr)
+		original, err := downloadM3U(ctx, urlStr, skipSSL)
 		if err != nil {
 			log.Error("Failed to download M3U from %s: %v", urlStr, err)
 			return 1
@@ -221,17 +222,28 @@ func run() int {
 	filteredContent := mergeParts(allFiltered)
 	originalContent := mergeParts(allOriginal)
 
-	// Step 2: Apply channel metadata from categories.txt.
+	// Step 2: Apply channel metadata.
 	filteredContent = applyMetadata(filteredContent, cfg)
 
 	// Step 3: Save files locally.
 	saveFile(filteredContent, cfg.LocalFilteredPlaylistPath(), cfg)
 	saveFile(originalContent, cfg.LocalAllCategoriesPlaylistPath(), cfg)
 
-	// Step 4: Process EPG (adds tvg-ids and filters EPG).
+	// Step 4: Create reusable S3 client (if not dry-run).
+	var s3Client *awss3.Client
+	if !dryRun {
+		var err error
+		s3Client, err = s3.NewClient(ctx, s3Endpoint, cfg.S3Region())
+		if err != nil {
+			log.Error("Failed to create S3 client: %v", err)
+			return 1
+		}
+	}
+
+	// Step 5: Process EPG.
 	if epgURL != "" {
 		var err error
-		filteredContent, err = processEPG(ctx, cfg, epgURL, filteredContent, dryRun)
+		filteredContent, err = processEPG(ctx, cfg, epgURL, filteredContent, s3Client, dryRun)
 		if err != nil {
 			log.Error("EPG processing failed: %v", err)
 			return 1
@@ -243,9 +255,9 @@ func run() int {
 		return 0
 	}
 
-	// Step 5: Upload everything to S3.
-	uploadBoth(ctx, filteredContent, s3Bucket, s3FilteredKey, s3Endpoint, cfg.S3Region())
-	uploadBoth(ctx, originalContent, s3Bucket, s3AllKey, s3Endpoint, cfg.S3Region())
+	// Step 6: Upload everything to S3 (reusing client).
+	uploadBoth(ctx, s3Client, filteredContent, s3Bucket, s3FilteredKey)
+	uploadBoth(ctx, s3Client, originalContent, s3Bucket, s3AllKey)
 
 	log.Info("Process completed successfully")
 	return 0

--- a/cmd/iptv-filter/main.go
+++ b/cmd/iptv-filter/main.go
@@ -1,9 +1,12 @@
 package main
 
 import (
+	"context"
 	"os"
+	"os/signal"
 	"path"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/ozyab/iptv/internal/config"
@@ -15,8 +18,21 @@ import (
 
 var log = utils.NewSanitizedLoggerWithPrefix("[main]")
 
-// saveFilteredM3ULocally writes M3U content to a file in the output directory.
-func saveFilteredM3ULocally(content, filename string, cfg *config.Config) {
+// gracefulCtx returns a context that is cancelled on SIGINT/SIGTERM.
+func gracefulCtx() (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithCancel(context.Background())
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		<-sigCh
+		log.Info("Received shutdown signal, cancelling operations...")
+		cancel()
+	}()
+	return ctx, cancel
+}
+
+// saveFile writes M3U content to a file in the output directory.
+func saveFile(content, filename string, cfg *config.Config) {
 	outputDir := cfg.OutputDir()
 	if err := os.MkdirAll(outputDir, 0755); err != nil {
 		log.Error("Failed to create output directory: %v", err)
@@ -24,11 +40,11 @@ func saveFilteredM3ULocally(content, filename string, cfg *config.Config) {
 	}
 	filepath := path.Join(outputDir, filename)
 	if err := os.WriteFile(filepath, []byte(content), 0644); err != nil {
-		log.Error("Failed to save M3U file: %v", err)
+		log.Error("Failed to save file: %v", err)
 		return
 	}
 	if fi, err := os.Stat(filepath); err == nil {
-		log.Info("M3U saved locally as %s (size: %.2f KB)", filepath, float64(fi.Size())/1024)
+		log.Info("Saved locally as %s (size: %.2f KB)", filepath, float64(fi.Size())/1024)
 	}
 }
 
@@ -58,7 +74,7 @@ func mergeParts(parts []string) string {
 	return strings.Join(mergedLines, "\n")
 }
 
-// parseM3USources splits comma-separated M3U URLs and returns valid URLs.
+// parseM3USources splits comma-separated M3U URLs.
 func parseM3USources(m3uURL string) []string {
 	parts := strings.Split(m3uURL, ",")
 	var valid []string
@@ -71,27 +87,97 @@ func parseM3USources(m3uURL string) []string {
 	return valid
 }
 
-// downloadAndFilterM3U downloads M3U from url, filters it, and returns filtered + original content.
-func downloadAndFilterM3U(urlStr string, categoriesToRemove, categoriesToRemoveSubstring, chNamesToExclude []string, customEPGURL string) (filtered, original string, err error) {
+// ─── Pipeline step: download M3U ────────────────────────────────────────────────
+
+func downloadM3U(ctx context.Context, urlStr string) (string, error) {
 	log.Info("Downloading M3U source: %s", urlStr)
-
-	if err = utils.Retry(3, 2*time.Second, 2.0, func() error {
-		original, err = m3u.DownloadM3U(urlStr)
-		return err
-	}); err != nil {
-		return "", "", err
-	}
-
-	filtered = m3u.FilterContent(original, categoriesToRemove, categoriesToRemoveSubstring, chNamesToExclude, customEPGURL)
-	return filtered, original, nil
+	var original string
+	err := utils.Retry(3, 2*time.Second, 2.0, func() error {
+		var e error
+		original, e = m3u.DownloadM3U(urlStr)
+		return e
+	})
+	return original, err
 }
 
-// uploadWithRetry wraps an S3 upload function with retry logic.
-func uploadWithRetry(fn func() error) {
+// ─── Pipeline step: filter M3U ──────────────────────────────────────────────────
+
+func filterM3U(content string, cfg *config.Config, customEPGURL string) string {
+	return m3u.FilterContent(
+		content,
+		config.CategoriesToRemove,
+		config.CategoriesToRemoveSubstring,
+		config.ChannelNamesToExclude,
+		customEPGURL,
+	)
+}
+
+// ─── Pipeline step: apply metadata ───────────────────────────────────────────────
+
+func applyMetadata(content string, cfg *config.Config) string {
+	categoriesFilePath := cfg.CategoriesFilePath()
+	if categoriesFilePath == "" {
+		return content
+	}
+	if categoriesMapping := m3u.ParseCategoriesFile(categoriesFilePath); len(categoriesMapping) > 0 {
+		return m3u.ApplyChannelMetadata(content, categoriesMapping)
+	}
+	return content
+}
+
+// ─── Pipeline step: process EPG ──────────────────────────────────────────────────
+
+func processEPG(ctx context.Context, cfg *config.Config, epgURL string, filteredContent string, dryRun bool) (string, error) {
+	log.Info("Starting EPG filtering process")
+
+	var epgContent string
+	if err := utils.Retry(3, 2*time.Second, 2.0, func() error {
+		var e error
+		epgContent, e = epg.DownloadEPG(ctx, epgURL, cfg)
+		return e
+	}); err != nil {
+		return filteredContent, err
+	}
+
+	// Build tvg-id map from EPG and add missing tvg-ids to filtered playlist.
+	epgNameToIDMap := epg.BuildEPGNameToIDMap(epgContent)
+	filteredContent = m3u.AddTvgIDsToPlaylist(filteredContent, epgNameToIDMap)
+	saveFile(filteredContent, cfg.LocalFilteredPlaylistPath(), cfg)
+
+	// Extract channel info and filter EPG programmes.
+	chIDs, chNames := epg.ExtractChannelInfoFromPlaylist(filteredContent)
+	filteredEPG, err := epg.FilterEPGContent(epgContent, chIDs, config.EPGExcludedCategories, config.EPGExcludedChannelIDs, chNames, cfg.EPGRetentionDays())
+	if err != nil {
+		return filteredContent, err
+	}
+
+	epg.SaveFilteredEPGLocally(filteredEPG, cfg.LocalFilteredEPGPath(), cfg)
+
+	// Upload filtered EPG to S3 (non-dry-run only).
+	if !dryRun {
+		uploadWithRetry(ctx, func() error {
+			return s3.UploadFileToS3(ctx, cfg.LocalFilteredEPGPath(), cfg.S3DefaultBucketName(), cfg.S3EPGKey(), cfg.OutputDir(), cfg.S3EndpointURL(), cfg.S3Region(), "application/gzip")
+		})
+	}
+
+	return filteredContent, nil
+}
+
+// ─── Pipeline step: upload ──────────────────────────────────────────────────────
+
+func uploadWithRetry(ctx context.Context, fn func() error) {
 	if err := utils.Retry(3, 2*time.Second, 2.0, fn); err != nil {
 		log.Error("Upload failed after retries: %v", err)
 	}
 }
+
+func uploadBoth(ctx context.Context, content, bucket, key, s3Endpoint, region string) {
+	uploadWithRetry(ctx, func() error {
+		return s3.UploadBoth(ctx, content, bucket, key, s3Endpoint, region)
+	})
+}
+
+// ─── Pipeline ────────────────────────────────────────────────────────────────────
 
 func run() int {
 	cfg := config.New()
@@ -103,13 +189,14 @@ func run() int {
 		return 1
 	}
 
+	ctx, cancel := gracefulCtx()
+	defer cancel()
+
 	m3uURL := cfg.M3USourceURL()
 	epgURL := cfg.EPGSourceURL()
 	s3Bucket := cfg.S3DefaultBucketName()
 	s3FilteredKey := cfg.S3FilteredPlaylistKey()
 	s3AllKey := cfg.S3AllCategoriesPlaylistKey()
-	categoriesToRemove := config.CategoriesToRemove
-	categoriesToRemoveSubstring := config.CategoriesToRemoveSubstring
 	dryRun := cfg.DryRun()
 	s3Endpoint := cfg.S3EndpointURL()
 	customEPGURL := cfg.BuildCustomEPGURL()
@@ -117,15 +204,16 @@ func run() int {
 	m3uURLs := parseM3USources(m3uURL)
 	log.Info("Processing %d M3U source(s)", len(m3uURLs))
 
-	// Download and filter each M3U source.
+	// Step 1: Download and filter M3U sources.
 	var allFiltered []string
 	var allOriginal []string
 	for _, urlStr := range m3uURLs {
-		filtered, original, err := downloadAndFilterM3U(urlStr, categoriesToRemove, categoriesToRemoveSubstring, config.ChannelNamesToExclude, customEPGURL)
+		original, err := downloadM3U(ctx, urlStr)
 		if err != nil {
 			log.Error("Failed to download M3U from %s: %v", urlStr, err)
 			return 1
 		}
+		filtered := filterM3U(original, cfg, customEPGURL)
 		allOriginal = append(allOriginal, original)
 		allFiltered = append(allFiltered, filtered)
 	}
@@ -133,20 +221,21 @@ func run() int {
 	filteredContent := mergeParts(allFiltered)
 	originalContent := mergeParts(allOriginal)
 
-	// Apply channel metadata from categories.txt if configured.
-	categoriesFilePath := cfg.CategoriesFilePath()
-	if categoriesFilePath != "" {
-		if categoriesMapping := m3u.ParseCategoriesFile(categoriesFilePath); len(categoriesMapping) > 0 {
-			filteredContent = m3u.ApplyChannelMetadata(filteredContent, categoriesMapping)
-		}
-	}
+	// Step 2: Apply channel metadata from categories.txt.
+	filteredContent = applyMetadata(filteredContent, cfg)
 
-	saveFilteredM3ULocally(filteredContent, cfg.LocalFilteredPlaylistPath(), cfg)
-	saveFilteredM3ULocally(originalContent, cfg.LocalAllCategoriesPlaylistPath(), cfg)
+	// Step 3: Save files locally.
+	saveFile(filteredContent, cfg.LocalFilteredPlaylistPath(), cfg)
+	saveFile(originalContent, cfg.LocalAllCategoriesPlaylistPath(), cfg)
 
-	// Process EPG: download, match tvg-ids, filter programmes.
+	// Step 4: Process EPG (adds tvg-ids and filters EPG).
 	if epgURL != "" {
-		processEPG(cfg, epgURL, &filteredContent, s3Bucket, s3Endpoint, dryRun)
+		var err error
+		filteredContent, err = processEPG(ctx, cfg, epgURL, filteredContent, dryRun)
+		if err != nil {
+			log.Error("EPG processing failed: %v", err)
+			return 1
+		}
 	}
 
 	if dryRun {
@@ -154,64 +243,12 @@ func run() int {
 		return 0
 	}
 
-	// Upload all content to S3.
-	uploadWithRetry(func() error {
-		_, err := s3.UploadArchiveToS3(filteredContent, s3Bucket, s3FilteredKey, s3Endpoint, cfg.S3Region())
-		return err
-	})
-	uploadWithRetry(func() error {
-		_, err := s3.UploadArchiveToS3(originalContent, s3Bucket, s3AllKey, s3Endpoint, cfg.S3Region())
-		return err
-	})
-	uploadWithRetry(func() error {
-		return s3.UploadToS3(filteredContent, s3Bucket, s3FilteredKey, s3Endpoint, cfg.S3Region(), "")
-	})
-	uploadWithRetry(func() error {
-		return s3.UploadToS3(originalContent, s3Bucket, s3AllKey, s3Endpoint, cfg.S3Region(), "")
-	})
+	// Step 5: Upload everything to S3.
+	uploadBoth(ctx, filteredContent, s3Bucket, s3FilteredKey, s3Endpoint, cfg.S3Region())
+	uploadBoth(ctx, originalContent, s3Bucket, s3AllKey, s3Endpoint, cfg.S3Region())
 
 	log.Info("Process completed successfully")
 	return 0
-}
-
-// processEPG handles EPG download, tvg-id matching, filtering, and upload.
-func processEPG(cfg *config.Config, epgURL string, filteredContent *string, s3Bucket, s3Endpoint string, dryRun bool) {
-	log.Info("Starting EPG filtering process")
-
-	var epgContent string
-	if err := utils.Retry(3, 2*time.Second, 2.0, func() error {
-		var e error
-		epgContent, e = epg.DownloadEPG(epgURL, cfg)
-		return e
-	}); err != nil {
-		log.Error("Failed to download EPG: %v", err)
-		return
-	}
-
-	// Build tvg-id map from EPG and add missing tvg-ids to filtered playlist.
-	epgNameToIDMap := epg.BuildEPGNameToIDMap(epgContent)
-	*filteredContent = m3u.AddTvgIDsToPlaylist(*filteredContent, epgNameToIDMap)
-	saveFilteredM3ULocally(*filteredContent, cfg.LocalFilteredPlaylistPath(), cfg)
-
-	// Extract channel info from playlist and filter EPG programmes.
-	chIDs, chNames := epg.ExtractChannelInfoFromPlaylist(*filteredContent)
-	retentionDays := cfg.EPGRetentionDays()
-
-	filteredEPG, err := epg.FilterEPGContent(epgContent, chIDs, config.EPGExcludedCategories, config.EPGExcludedChannelIDs, chNames, retentionDays)
-	if err != nil {
-		log.Error("Failed to filter EPG: %v", err)
-		return
-	}
-
-	epg.SaveFilteredEPGLocally(filteredEPG, cfg.LocalFilteredEPGPath(), cfg)
-
-	// Upload filtered EPG to S3 (non-dry-run only).
-	if !dryRun {
-		outputDir := cfg.OutputDir()
-		uploadWithRetry(func() error {
-			return s3.UploadFileToS3(cfg.LocalFilteredEPGPath(), s3Bucket, cfg.S3EPGKey(), outputDir, s3Endpoint, cfg.S3Region(), "application/gzip")
-		})
-	}
 }
 
 func main() {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -170,6 +170,13 @@ var CategoriesToRemove = []string{
 
 	"MavTV ⭐️",
 	"aleks-u-romki* 😊",
+
+	// Кино и сериалы (bold unicode)
+	"𝐊𝐢𝐧𝐨",
+	"𝕂иℍ𝕠",
+
+	// Региональные категории
+	"РОССИЯ+",
 }
 
 // CategoriesToRemoveSubstring lists substrings to match against group-title (case-insensitive).
@@ -229,7 +236,7 @@ var CategoriesToRemoveSubstring = []string{
 	"швейцари", "шри-ланка",
 	"эквадор", "эфиопи", "япони",
 // Кино / Сериалы / Шоу (исключаемые категории)
-	"девяностые", "кинозал", "киноstream",
+	"кино", "девяностые", "кинозал", "киноstream",
 	"сериал", "криминальная", "kinowalk",
 	"екб", "kino", "viju",
 	"тайны", "уральские",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,49 +9,94 @@ import (
 	"strings"
 )
 
-// Config is a stateless configuration reader.
-// All methods read directly from environment variables for simplicity.
-type Config struct{}
+// Config caches all configuration values on creation for fast access.
+type Config struct {
+	m3uSourceURL    string
+	s3BucketName    string
+	s3FilteredKey   string
+	s3AllKey        string
+	s3EndpointURL   string
+	s3Region        string
+	epgSourceURL    string
+	s3EPGKey        string
+	localEPGPath    string
+	epgRetention    int
+	outputDir       string
+	categoriesFile  string
+	dryRun          bool
+	skipSSLVerify   bool
+}
 
+// New reads all environment variables once and caches them.
 func New() *Config {
-	return &Config{}
+	return &Config{
+		m3uSourceURL:  os.Getenv("M3U_SOURCE_URL"),
+		s3BucketName:  os.Getenv("S3_BUCKET_NAME"),
+		s3FilteredKey: envOrDefault("S3_OBJECT_KEY", "playlist.m3u"),
+		s3AllKey:      "playlist-all.m3u",
+		s3EndpointURL: os.Getenv("S3_ENDPOINT_URL"),
+		s3Region:      envOrDefault("S3_REGION", "us-east-1"),
+		epgSourceURL:  os.Getenv("EPG_SOURCE_URL"),
+		s3EPGKey:      os.Getenv("S3_EPG_KEY"),
+		localEPGPath:  envOrDefault("LOCAL_EPG_PATH", "epg.xml.gz"),
+		epgRetention:  envIntOrDefault("EPG_RETENTION_DAYS", 10),
+		outputDir:     envOrDefault("OUTPUT_DIR", "output"),
+		categoriesFile: os.Getenv("CATEGORIES_FILE_PATH"),
+		dryRun:        isTruthy(os.Getenv("DRY_RUN")),
+		skipSSLVerify: isTruthy(os.Getenv("SKIP_SSL_VERIFY")),
+	}
 }
 
-// M3USourceURL returns the M3U source URL (comma-separated for multiple sources).
-func (c *Config) M3USourceURL() string {
-	return os.Getenv("M3U_SOURCE_URL")
+func envOrDefault(key, defaultVal string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return defaultVal
 }
+
+func envIntOrDefault(key string, defaultVal int) int {
+	val := os.Getenv(key)
+	if val == "" {
+		return defaultVal
+	}
+	n, err := strconv.Atoi(val)
+	if err != nil || n < 1 {
+		return defaultVal
+	}
+	return n
+}
+
+func isTruthy(val string) bool {
+	lower := strings.ToLower(val)
+	return lower == "true" || val == "1" || lower == "yes" || lower == "on"
+}
+
+// M3USourceURL returns the M3U source URL.
+func (c *Config) M3USourceURL() string { return c.m3uSourceURL }
 
 // S3DefaultBucketName returns the S3 bucket name.
-func (c *Config) S3DefaultBucketName() string {
-	return os.Getenv("S3_BUCKET_NAME")
-}
+func (c *Config) S3DefaultBucketName() string { return c.s3BucketName }
 
-// S3FilteredPlaylistKey returns the S3 key for the filtered playlist (default: playlist.m3u).
-func (c *Config) S3FilteredPlaylistKey() string {
-	if v := os.Getenv("S3_OBJECT_KEY"); v != "" {
-		return v
-	}
-	return "playlist.m3u"
-}
+// S3FilteredPlaylistKey returns the S3 key for the filtered playlist.
+func (c *Config) S3FilteredPlaylistKey() string { return c.s3FilteredKey }
 
 // S3AllCategoriesPlaylistKey returns the S3 key for the unfiltered playlist.
-func (c *Config) S3AllCategoriesPlaylistKey() string {
-	return "playlist-all.m3u"
-}
+func (c *Config) S3AllCategoriesPlaylistKey() string { return c.s3AllKey }
 
 // S3EndpointURL returns the S3-compatible endpoint URL.
-func (c *Config) S3EndpointURL() string {
-	return os.Getenv("S3_ENDPOINT_URL")
-}
+func (c *Config) S3EndpointURL() string { return c.s3EndpointURL }
 
-// S3Region returns the S3 region (default: us-east-1).
-func (c *Config) S3Region() string {
-	if v := os.Getenv("S3_REGION"); v != "" {
-		return v
-	}
-	return "us-east-1"
-}
+// S3Region returns the S3 region.
+func (c *Config) S3Region() string { return c.s3Region }
+
+// EPGSourceURL returns the EPG XML source URL.
+func (c *Config) EPGSourceURL() string { return c.epgSourceURL }
+
+// S3EPGKey returns the S3 key for the EPG file.
+func (c *Config) S3EPGKey() string { return c.s3EPGKey }
+
+// SkipSSLVerify returns whether to skip SSL certificate verification.
+func (c *Config) SkipSSLVerify() bool { return c.skipSSLVerify }
 
 // MaxM3UFileSize is the maximum M3U download size (100 MB).
 const MaxM3UFileSize = 100 * 1024 * 1024
@@ -59,122 +104,92 @@ const MaxM3UFileSize = 100 * 1024 * 1024
 // MaxEPGFileSize is the maximum EPG download size (500 MB).
 const MaxEPGFileSize = 500 * 1024 * 1024
 
-// EPGRetentionDays returns how many days of EPG data to keep (default: 10).
-func (c *Config) EPGRetentionDays() int {
-	val := os.Getenv("EPG_RETENTION_DAYS")
-	if val == "" {
-		return 10
-	}
-	n, err := strconv.Atoi(val)
-	if err != nil || n < 1 {
-		return 10
-	}
-	return n
-}
+// EPGRetentionDays returns how many days of EPG data to keep.
+func (c *Config) EPGRetentionDays() int { return c.epgRetention }
 
 // LocalFilteredPlaylistPath returns the local filename for the filtered playlist.
-func (c *Config) LocalFilteredPlaylistPath() string {
-	if v := os.Getenv("S3_OBJECT_KEY"); v != "" {
-		return v
-	}
-	return "playlist.m3u"
-}
+func (c *Config) LocalFilteredPlaylistPath() string { return c.s3FilteredKey }
 
 // LocalAllCategoriesPlaylistPath returns the local filename for the unfiltered playlist.
 func (c *Config) LocalAllCategoriesPlaylistPath() string {
-	s3Key := os.Getenv("S3_OBJECT_KEY")
-	if s3Key == "" {
-		s3Key = "playlist.m3u"
+	if idx := strings.LastIndex(c.s3FilteredKey, "."); idx >= 0 {
+		return c.s3FilteredKey[:idx] + "-all" + c.s3FilteredKey[idx:]
 	}
-	if idx := strings.LastIndex(s3Key, "."); idx >= 0 {
-		return s3Key[:idx] + "-all" + s3Key[idx:]
-	}
-	return s3Key + "-all"
-}
-
-// EPGSourceURL returns the EPG XML source URL.
-func (c *Config) EPGSourceURL() string {
-	return os.Getenv("EPG_SOURCE_URL")
-}
-
-// S3EPGKey returns the S3 key for the EPG file.
-func (c *Config) S3EPGKey() string {
-	return os.Getenv("S3_EPG_KEY")
+	return c.s3FilteredKey + "-all"
 }
 
 // LocalEPGPath returns the local filename for the downloaded EPG.
-func (c *Config) LocalEPGPath() string {
-	if v := os.Getenv("LOCAL_EPG_PATH"); v != "" {
-		return v
-	}
-	return "epg.xml.gz"
-}
+func (c *Config) LocalEPGPath() string { return c.localEPGPath }
 
 // LocalFilteredEPGPath returns the local filename for the filtered EPG.
 func (c *Config) LocalFilteredEPGPath() string {
-	s3Key := os.Getenv("S3_EPG_KEY")
-	if s3Key == "" {
-		s3Key = "epg.xml.gz"
+	if idx := strings.LastIndex(c.s3EPGKey, "."); idx >= 0 {
+		return c.s3EPGKey[:idx] + "-filtered" + c.s3EPGKey[idx:]
 	}
-	if idx := strings.LastIndex(s3Key, "."); idx >= 0 {
-		return s3Key[:idx] + "-filtered" + s3Key[idx:]
+	return c.s3EPGKey + "-filtered"
+}
+
+// DryRun returns true if dry-run mode is enabled.
+func (c *Config) DryRun() bool { return c.dryRun }
+
+// OutputDir returns the local output directory.
+func (c *Config) OutputDir() string { return c.outputDir }
+
+// CategoriesFilePath returns the optional path to categories.txt.
+func (c *Config) CategoriesFilePath() string { return c.categoriesFile }
+
+// BuildCustomEPGURL constructs the public URL for the EPG file in S3.
+func (c *Config) BuildCustomEPGURL() string {
+	parsed, err := url.Parse(c.s3EndpointURL)
+	if err != nil {
+		hostPart := c.s3EndpointURL
+		if idx := strings.Index(c.s3EndpointURL, "://"); idx >= 0 {
+			hostPart = c.s3EndpointURL[idx+3:]
+		}
+		return fmt.Sprintf("https://%s.%s/%s", c.s3BucketName, hostPart, c.s3EPGKey)
 	}
-	return s3Key + "-filtered"
+	if parsed.Path != "" && parsed.Path != "/" {
+		return fmt.Sprintf("%s://%s%s/%s/%s", parsed.Scheme, parsed.Host, strings.TrimRight(parsed.Path, "/"), c.s3BucketName, c.s3EPGKey)
+	}
+	return fmt.Sprintf("%s://%s.%s/%s", parsed.Scheme, c.s3BucketName, parsed.Host, c.s3EPGKey)
 }
 
 // CategoriesToRemove is the deny-list of channel groups to filter out (exact match, case-insensitive).
+// Only normalized variants are kept — normalization strips leading numbers and trailing emojis
+// before matching, so the original emojified variants would never match.
 var CategoriesToRemove = []string{
+	// Adult / 18+
 	"Взрослые",
+	"Adult (18+)",
+	"XXX (18+)",
+	// Религия
 	"Религия",
 	"Религиозные",
-	"40.РЕЛИГИЯ 🧙‍♂️",
-	"РЕЛИГИЯ",           // после нормализации (без цифр и эмодзи)
-	"Adult (18+) ❤️",
-	"Adult (18+)",       // после нормализации (без ❤️)
-	"XXX (18+) 🔞",
-	"XXX (18+)",         // после нормализации (без 🔞)
-	"💲💲💲Поддержи Проект💲💲💲",
-	"🔺 INFO 🔺",
-	"🔺 INFO",           // после нормализации (без 🔺)
+	// Поддержка / INFO
+	"💲💲💲Поддержи Проект💲💲💲",   // leading emojis — normalization only strips trailing
+	"🔺 INFO",
 	// АнтиРоссия / Украина
-	"10.АнтиРОССИЙСКИЕ 🇪🇺",
-	"АнтиРОССИЙСКИЕ",    // после нормализации
-	"12.𝕐𝕜𝕡𝕒Їℍ𝕒 🇺🇦",
-	"𝕐𝕜𝕡𝕒Їℍ𝕒",         // после нормализации
+	"АнтиРОССИЙСКИЕ",
+	"𝕐𝕜𝕡𝕒Їℍ𝕒",
 	"Українські",
-	"Украина 🇺🇦",
-	"Украина",           // после нормализации
-	"Наш Нет 🇺🇦",
-	"Наш Нет",           // после нормализации
+	"Украина",
+	"Наш Нет",
 	// Спорт (bold unicode)
-	"34.ℂп𝕠𝕡т ⚽️",
-	"ℂп𝕠𝕡т",            // после нормализации
-	"37.186 ♻️",
-	"186",               // после нормализации
+	"ℂп𝕠𝕡т",
+	"186",
 	// Музыка (bold unicode)
-	"43.РАДИО ТВ 📻",
-	"РАДИО ТВ",          // после нормализации
-	"44.𝕄𝕦𝕤𝕚𝕔 🇷🇺",
-	"𝕄𝕦𝕤𝕚𝕔",           // после нормализации
-	"45.𝕄𝕦𝕤𝕚𝕔 🇪🇺",
-	"𝕄𝕦𝕤𝕚𝕔",           // после нормализации
-
+	"РАДИО ТВ",
+	"𝕄𝕦𝕤𝕚𝕔",
 	// Служебные / Тестовые (bold unicode)
-	"56.𝕋𝕧ℤ𝕒𝕋𝕒𝕜 📼",
-	"𝕋𝕧ℤ𝕒𝕋𝕒𝕜",         // после нормализации
-	"62.32 📼",
-	"32",                // после нормализации
-	"TVS ☆",
-	"TVS",               // после нормализации
+	"𝕋𝕧ℤ𝕒𝕋𝕒𝕜",
+	"32",
+	"TVS",
 	"TvZaTak",
-
-	"MavTV ⭐️",
-	"aleks-u-romki* 😊",
-
+	"MavTV ⭐️",                    // trailing emoji — normalization strips it
+	"aleks-u-romki* 😊",            // trailing emoji — normalization strips it
 	// Кино и сериалы (bold unicode)
 	"𝐊𝐢𝐧𝐨",
 	"𝕂иℍ𝕠",
-
 	// Региональные категории
 	"РОССИЯ+",
 }
@@ -235,7 +250,7 @@ var CategoriesToRemoveSubstring = []string{
 	"чили",
 	"швейцари", "шри-ланка",
 	"эквадор", "эфиопи", "япони",
-// Кино / Сериалы / Шоу (исключаемые категории)
+	// Кино / Сериалы / Шоу (исключаемые категории)
 	"кино", "девяностые", "кинозал", "киноstream",
 	"сериал", "криминальная", "kinowalk",
 	"екб", "kino", "viju",
@@ -269,59 +284,15 @@ var EPGExcludedChannelIDs = []string{
 	"810", "6419",
 }
 
-// OutputDir returns the local output directory (default: output/).
-func (c *Config) OutputDir() string {
-	if v := os.Getenv("OUTPUT_DIR"); v != "" {
-		return v
-	}
-	return "output"
-}
-
-// CategoriesFilePath returns the optional path to categories.txt for metadata overrides.
-func (c *Config) CategoriesFilePath() string {
-	return os.Getenv("CATEGORIES_FILE_PATH")
-}
-
-// DryRun returns true if DRY_RUN env var is set to a truthy value.
-func (c *Config) DryRun() bool {
-	return strings.EqualFold(os.Getenv("DRY_RUN"), "true") ||
-		os.Getenv("DRY_RUN") == "1" ||
-		strings.EqualFold(os.Getenv("DRY_RUN"), "yes") ||
-		strings.EqualFold(os.Getenv("DRY_RUN"), "on")
-}
-
-// BuildCustomEPGURL constructs the public URL for the EPG file in S3.
-// Used to inject url-tvg into the M3U header.
-func (c *Config) BuildCustomEPGURL() string {
-	endpointURL := c.S3EndpointURL()
-	bucketName := c.S3DefaultBucketName()
-	epgKey := c.S3EPGKey()
-
-	parsed, err := url.Parse(endpointURL)
-	if err != nil {
-		// Try to extract host part manually
-		hostPart := endpointURL
-		if idx := strings.Index(endpointURL, "://"); idx >= 0 {
-			hostPart = endpointURL[idx+3:]
-		}
-		return fmt.Sprintf("https://%s.%s/%s", bucketName, hostPart, epgKey)
-	}
-	if parsed.Path != "" && parsed.Path != "/" {
-		return fmt.Sprintf("%s://%s%s/%s/%s", parsed.Scheme, parsed.Host, strings.TrimRight(parsed.Path, "/"), bucketName, epgKey)
-	}
-	return fmt.Sprintf("%s://%s.%s/%s", parsed.Scheme, bucketName, parsed.Host, epgKey)
-}
-
 // Validate checks all required configuration and returns a list of errors.
 func (c *Config) Validate() []string {
 	var errors []string
 	placeholderPatterns := []string{"your-", "your_provider", "your-epg-provider"}
 
-	m3uURL := c.M3USourceURL()
-	if m3uURL == "" {
+	if c.m3uSourceURL == "" {
 		errors = append(errors, "M3U_SOURCE_URL must be specified")
 	} else {
-		lower := strings.ToLower(m3uURL)
+		lower := strings.ToLower(c.m3uSourceURL)
 		for _, p := range placeholderPatterns {
 			if strings.Contains(lower, p) {
 				errors = append(errors, "M3U_SOURCE_URL appears to be a placeholder. Please set a valid URL")
@@ -329,7 +300,7 @@ func (c *Config) Validate() []string {
 			}
 		}
 		if len(errors) == 0 {
-			urls := strings.Split(m3uURL, ",")
+			urls := strings.Split(c.m3uSourceURL, ",")
 			hasValid := false
 			for _, u := range urls {
 				u = strings.TrimSpace(u)
@@ -346,52 +317,47 @@ func (c *Config) Validate() []string {
 		}
 	}
 
-	epgURL := c.EPGSourceURL()
-	if epgURL == "" {
+	if c.epgSourceURL == "" {
 		errors = append(errors, "EPG_SOURCE_URL must be specified")
 	} else {
-		lower := strings.ToLower(epgURL)
+		lower := strings.ToLower(c.epgSourceURL)
 		for _, p := range placeholderPatterns {
 			if strings.Contains(lower, p) {
 				errors = append(errors, "EPG_SOURCE_URL appears to be a placeholder. Please set a valid URL")
 				break
 			}
 		}
-		if len(errors) == 0 && !strings.HasPrefix(epgURL, "http://") && !strings.HasPrefix(epgURL, "https://") {
+		if len(errors) == 0 && !strings.HasPrefix(c.epgSourceURL, "http://") && !strings.HasPrefix(c.epgSourceURL, "https://") {
 			errors = append(errors, "EPG_SOURCE_URL must be a valid HTTP/HTTPS URL")
 		}
 	}
 
-	bucketName := c.S3DefaultBucketName()
-	if bucketName == "" {
+	if c.s3BucketName == "" {
 		errors = append(errors, "S3_BUCKET_NAME must be specified")
-	} else if len(bucketName) < 3 || len(bucketName) > 63 {
+	} else if len(c.s3BucketName) < 3 || len(c.s3BucketName) > 63 {
 		errors = append(errors, "S3_BUCKET_NAME must be between 3 and 63 characters")
 	}
 
-	playlistKey := c.S3FilteredPlaylistKey()
-	if playlistKey == "" || strings.Contains(playlistKey, "..") || strings.HasPrefix(playlistKey, "/") {
+	if c.s3FilteredKey == "" || strings.Contains(c.s3FilteredKey, "..") || strings.HasPrefix(c.s3FilteredKey, "/") {
 		errors = append(errors, "S3_OBJECT_KEY must not contain '..' or start with '/'")
 	}
 
-	epgKey := c.S3EPGKey()
-	if epgKey == "" || strings.Contains(epgKey, "..") || strings.HasPrefix(epgKey, "/") {
+	if c.s3EPGKey == "" || strings.Contains(c.s3EPGKey, "..") || strings.HasPrefix(c.s3EPGKey, "/") {
 		errors = append(errors, "S3_EPG_KEY must not contain '..' or start with '/'")
 	}
 
-	endpointURL := c.S3EndpointURL()
-	if endpointURL == "" {
+	if c.s3EndpointURL == "" {
 		errors = append(errors, "S3_ENDPOINT_URL must be specified")
-	} else if !strings.HasPrefix(endpointURL, "http://") && !strings.HasPrefix(endpointURL, "https://") {
+	} else if !strings.HasPrefix(c.s3EndpointURL, "http://") && !strings.HasPrefix(c.s3EndpointURL, "https://") {
 		errors = append(errors, "S3_ENDPOINT_URL must be a valid HTTP/HTTPS URL")
 	} else {
-		parsed, err := url.Parse(endpointURL)
+		parsed, err := url.Parse(c.s3EndpointURL)
 		if err == nil && strings.Contains(parsed.Host, "@") {
 			errors = append(errors, "S3_ENDPOINT_URL should not contain credentials in the URL")
 		}
 	}
 
-	if c.S3Region() == "" {
+	if c.s3Region == "" {
 		errors = append(errors, "S3_REGION must be specified")
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -129,6 +129,11 @@ func (c *Config) LocalFilteredEPGPath() string {
 	return c.s3EPGKey + "-filtered"
 }
 
+// EnsureOutputDir creates the output directory if it doesn't exist.
+func (c *Config) EnsureOutputDir() error {
+	return os.MkdirAll(c.outputDir, 0755)
+}
+
 // DryRun returns true if dry-run mode is enabled.
 func (c *Config) DryRun() bool { return c.dryRun }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -110,6 +110,11 @@ func TestCategoriesToRemove(t *testing.T) {
 		"TvZaTak",
 		"MavTV ⭐️",
 		"aleks-u-romki* 😊",
+
+		"𝐊𝐢𝐧𝐨",
+		"𝕂иℍ𝕠",
+
+		"РОССИЯ+",
 	}
 	if len(CategoriesToRemove) != len(expected) {
 		t.Errorf("expected %d categories, got %d", len(expected), len(CategoriesToRemove))

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"os"
+	"strings"
 	"testing"
 )
 
@@ -70,50 +71,29 @@ func TestLocalPlaylistPaths(t *testing.T) {
 func TestCategoriesToRemove(t *testing.T) {
 	expected := []string{
 		"Взрослые",
+		"Adult (18+)",
+		"XXX (18+)",
 		"Религия",
 		"Религиозные",
-		"40.РЕЛИГИЯ 🧙‍♂️",
-		"РЕЛИГИЯ",
-		"Adult (18+) ❤️",
-		"Adult (18+)",
-		"XXX (18+) 🔞",
-		"XXX (18+)",
 		"💲💲💲Поддержи Проект💲💲💲",
-		"🔺 INFO 🔺",
 		"🔺 INFO",
-		"10.АнтиРОССИЙСКИЕ 🇪🇺",
 		"АнтиРОССИЙСКИЕ",
-		"12.𝕐𝕜𝕡𝕒Їℍ𝕒 🇺🇦",
 		"𝕐𝕜𝕡𝕒Їℍ𝕒",
 		"Українські",
-		"Украина 🇺🇦",
 		"Украина",
-		"Наш Нет 🇺🇦",
 		"Наш Нет",
-		"34.ℂп𝕠𝕡т ⚽️",
 		"ℂп𝕠𝕡т",
-		"37.186 ♻️",
 		"186",
-		"43.РАДИО ТВ 📻",
 		"РАДИО ТВ",
-		"44.𝕄𝕦𝕤𝕚𝕔 🇷🇺",
 		"𝕄𝕦𝕤𝕚𝕔",
-		"45.𝕄𝕦𝕤𝕚𝕔 🇪🇺",
-		"𝕄𝕦𝕤𝕚𝕔",
-
-		"56.𝕋𝕧ℤ𝕒𝕋𝕒𝕜 📼",
 		"𝕋𝕧ℤ𝕒𝕋𝕒𝕜",
-		"62.32 📼",
 		"32",
-		"TVS ☆",
 		"TVS",
 		"TvZaTak",
 		"MavTV ⭐️",
 		"aleks-u-romki* 😊",
-
 		"𝐊𝐢𝐧𝐨",
 		"𝕂иℍ𝕠",
-
 		"РОССИЯ+",
 	}
 	if len(CategoriesToRemove) != len(expected) {
@@ -122,6 +102,18 @@ func TestCategoriesToRemove(t *testing.T) {
 	for i, v := range expected {
 		if CategoriesToRemove[i] != v {
 			t.Errorf("expected category %q, got %q", v, CategoriesToRemove[i])
+		}
+	}
+}
+
+func TestCategoriesToRemoveSubstring(t *testing.T) {
+	// Verify all substrings are non-empty and in lowercase.
+	for i, s := range CategoriesToRemoveSubstring {
+		if s == "" {
+			t.Errorf("CategoriesToRemoveSubstring[%d] is empty", i)
+		}
+		if s != strings.ToLower(s) {
+			t.Errorf("CategoriesToRemoveSubstring[%d] is not lowercase: %q", i, s)
 		}
 	}
 }
@@ -138,6 +130,18 @@ func TestChannelNamesToExclude(t *testing.T) {
 	}
 }
 
+func TestEPGExcludedCategories(t *testing.T) {
+	if len(EPGExcludedCategories) == 0 {
+		t.Error("expected at least one EPG excluded category")
+	}
+}
+
+func TestEPGExcludedChannelIDs(t *testing.T) {
+	if len(EPGExcludedChannelIDs) == 0 {
+		t.Error("expected at least one EPG excluded channel ID")
+	}
+}
+
 func TestEPGRetentionDaysDefault(t *testing.T) {
 	cfg := New()
 	if cfg.EPGRetentionDays() != 10 {
@@ -151,5 +155,21 @@ func TestEPGRetentionDaysFromEnv(t *testing.T) {
 	cfg := New()
 	if cfg.EPGRetentionDays() != 7 {
 		t.Errorf("expected EPGRetentionDays to be 7, got %d", cfg.EPGRetentionDays())
+	}
+}
+
+func TestSkipSSLVerifyDefault(t *testing.T) {
+	cfg := New()
+	if cfg.SkipSSLVerify() {
+		t.Error("expected SkipSSLVerify to be false by default")
+	}
+}
+
+func TestSkipSSLVerifyFromEnv(t *testing.T) {
+	os.Setenv("SKIP_SSL_VERIFY", "true")
+	defer os.Unsetenv("SKIP_SSL_VERIFY")
+	cfg := New()
+	if !cfg.SkipSSLVerify() {
+		t.Error("expected SkipSSLVerify to be true when SKIP_SSL_VERIFY=true")
 	}
 }

--- a/internal/epg/processor.go
+++ b/internal/epg/processor.go
@@ -222,19 +222,20 @@ func FilterEPGContent(epgContent string, channelIDs map[string]string, excludedC
 		}
 	}
 
-	// Stream-parse EPG XML to avoid loading 463MB into Go structs.
+	// Pre-compute retention window to avoid time.Now() calls in the loop.
+	now := time.Now()
+	oneHourAgo := now.Add(-1 * time.Hour)
+	retentionLater := now.AddDate(0, 0, retentionDays)
+
+	// Single-pass streaming parse: channels come before programmes in XMLTV.
 	var result TV
 	result.XMLName = xml.Name{Local: "tv"}
 
-	decoder := xml.NewDecoder(bytes.NewReader([]byte(epgContent)))
-
-	// First pass (channels): build channel keep-set while streaming.
 	channelsToKeep := make(map[string]bool)
-
-	// Build EPG channel display-name map first (pass 1).
+	checkedChannels := make(map[string]bool)
 	epgChDisplayNames := make(map[string][]string)
 
-	decoder = xml.NewDecoder(bytes.NewReader([]byte(epgContent))) // reset
+	decoder := xml.NewDecoder(bytes.NewReader([]byte(epgContent)))
 	for {
 		tok, err := decoder.Token()
 		if err == io.EOF {
@@ -244,169 +245,126 @@ func FilterEPGContent(epgContent string, channelIDs map[string]string, excludedC
 			return "", fmt.Errorf("error parsing EPG XML token: %w", err)
 		}
 
-		if se, ok := tok.(xml.StartElement); ok && se.Name.Local == "channel" {
+		se, ok := tok.(xml.StartElement)
+		if !ok {
+			continue
+		}
+
+		switch se.Name.Local {
+		case "channel":
 			var ch Channel
 			if err := decoder.DecodeElement(&ch, &se); err != nil {
 				logger.Warning("Error decoding channel element: %v", err)
 				continue
 			}
+
+			// Collect display names for name-based EPG matching.
 			for _, dn := range ch.DisplayName {
 				if dn.Value != "" {
 					epgChDisplayNames[ch.ID] = append(epgChDisplayNames[ch.ID], strings.ToLower(strings.TrimSpace(dn.Value)))
 				}
 			}
-		}
-	}
 
-	// Second pass: filter programmes and channels.
-	decoder = xml.NewDecoder(bytes.NewReader([]byte(epgContent))) // reset
-	checkedChannels := make(map[string]bool)
-
-	for {
-		tok, err := decoder.Token()
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			return "", fmt.Errorf("error parsing EPG XML token: %w", err)
-		}
-
-		switch se := tok.(type) {
-		case xml.StartElement:
-			switch se.Name.Local {
-			case "channel":
-				var ch Channel
-				if err := decoder.DecodeElement(&ch, &se); err != nil {
-					logger.Warning("Error decoding channel element: %v", err)
-					continue
-				}
-
-				// Check if this channel should be kept.
-				_, matchedByID := channelIDs[ch.ID]
-				if !matchedByID {
-					// Check by name.
-					if dns, ok := epgChDisplayNames[ch.ID]; ok && len(chNamesNormalized) > 0 {
-						for _, dn := range dns {
-							if chNamesNormalized[dn] {
-								matchedByID = true
-								break
-							}
-						}
-					}
-				}
-
-				shouldKeep := matchedByID
-				if shouldKeep {
-					// Check exclusions.
-					if excludedIDSet[ch.ID] {
-						shouldKeep = false
-					}
-				}
-
-				if shouldKeep {
-					channelsToKeep[ch.ID] = true
-					result.Channels = append(result.Channels, Channel{
-						ID: ch.ID,
-						DisplayName: func() []DisplayName {
-							if len(ch.DisplayName) > 0 {
-								return []DisplayName{{Lang: ch.DisplayName[0].Lang, Value: ch.DisplayName[0].Value}}
-							}
-							return nil
-						}(),
-					})
-				}
-
-			case "programme":
-				// Only process programmes for kept channels.
-				chRef := ""
-				for _, attr := range se.Attr {
-					if attr.Name.Local == "channel" {
-						chRef = attr.Value
+			// Check if this channel should be kept by ID or name.
+			_, matchedByID := channelIDs[ch.ID]
+			if !matchedByID && len(chNamesNormalized) > 0 {
+				for _, dn := range epgChDisplayNames[ch.ID] {
+					if chNamesNormalized[dn] {
+						matchedByID = true
 						break
 					}
 				}
+			}
 
-				if !channelsToKeep[chRef] {
-					// Skip this programme.
-					if err := decoder.Skip(); err != nil {
-						logger.Warning("Error skipping programme element: %v", err)
+			shouldKeep := matchedByID && !excludedIDSet[ch.ID]
+			if shouldKeep {
+				channelsToKeep[ch.ID] = true
+				result.Channels = append(result.Channels, Channel{
+					ID: ch.ID,
+					DisplayName: func() []DisplayName {
+						if len(ch.DisplayName) > 0 {
+							return []DisplayName{{Lang: ch.DisplayName[0].Lang, Value: ch.DisplayName[0].Value}}
+						}
+						return nil
+					}(),
+				})
+			}
+
+		case "programme":
+			chRef := ""
+			for _, attr := range se.Attr {
+				if attr.Name.Local == "channel" {
+					chRef = attr.Value
+					break
+				}
+			}
+
+			if !channelsToKeep[chRef] {
+				if err := decoder.Skip(); err != nil {
+					logger.Warning("Error skipping programme element: %v", err)
+				}
+				continue
+			}
+
+			var prog Programme
+			if err := decoder.DecodeElement(&prog, &se); err != nil {
+				logger.Warning("Error decoding programme element: %v", err)
+				continue
+			}
+
+			// Check exclusion by category or ID (once per channel).
+			if !checkedChannels[prog.Channel] {
+				checkedChannels[prog.Channel] = true
+				catToCheck := channelIDs[prog.Channel]
+
+				exclude := false
+				if catToCheck != "" {
+					catLower := strings.ToLower(catToCheck)
+					for _, ec := range excludedCatLower {
+						if catLower == ec {
+							exclude = true
+							break
+						}
 					}
+				}
+				if excludedIDSet[prog.Channel] {
+					exclude = true
+				}
+
+				if exclude {
+					delete(channelsToKeep, prog.Channel)
+					for i, ch := range result.Channels {
+						if ch.ID == prog.Channel {
+							result.Channels = append(result.Channels[:i], result.Channels[i+1:]...)
+							break
+						}
+					}
+					checkedChannels[prog.Channel] = false
 					continue
 				}
+			}
 
-				var prog Programme
-				if err := decoder.DecodeElement(&prog, &se); err != nil {
-					logger.Warning("Error decoding programme element: %v", err)
-					continue
-				}
+			if !channelsToKeep[prog.Channel] {
+				continue
+			}
 
-				// Apply retention window.
-				if !checkedChannels[prog.Channel] {
-					checkedChannels[prog.Channel] = true
+			// Apply time retention filter.
+			startMatch := epgTimeRegex.FindStringSubmatch(prog.Start)
+			stopMatch := epgTimeRegex.FindStringSubmatch(prog.Stop)
 
-					catToCheck := channelIDs[prog.Channel]
-					if catToCheck == "" {
-						for chID := range channelNames {
-							_ = chID // matched by name elsewhere
-						}
-					}
-
-					// Check category exclusion.
-					if catToCheck != "" {
-						catLower := strings.ToLower(catToCheck)
-						for _, ec := range excludedCatLower {
-							if catLower == ec {
-								// Remove channel from keep-set.
-								delete(channelsToKeep, prog.Channel)
-								// Also remove from result.Channels.
-								for i, ch := range result.Channels {
-									if ch.ID == prog.Channel {
-										result.Channels = append(result.Channels[:i], result.Channels[i+1:]...)
-										break
-									}
-								}
-								checkedChannels[prog.Channel] = false
-								break
-							}
-						}
-					}
-					if excludedIDSet[prog.Channel] {
-						delete(channelsToKeep, prog.Channel)
-						for i, ch := range result.Channels {
-							if ch.ID == prog.Channel {
-								result.Channels = append(result.Channels[:i], result.Channels[i+1:]...)
-								break
-							}
-						}
-						checkedChannels[prog.Channel] = false
+			include := true
+			if startMatch != nil && stopMatch != nil {
+				startTime, err1 := parseEPGTime(startMatch)
+				stopTime, err2 := parseEPGTime(stopMatch)
+				if err1 == nil && err2 == nil {
+					if stopTime.Before(oneHourAgo) || startTime.After(retentionLater) {
+						include = false
 					}
 				}
+			}
 
-				if !channelsToKeep[prog.Channel] {
-					continue
-				}
-
-				// Apply time retention filter.
-				startMatch := epgTimeRegex.FindStringSubmatch(prog.Start)
-				stopMatch := epgTimeRegex.FindStringSubmatch(prog.Stop)
-
-				include := true
-				if startMatch != nil && stopMatch != nil {
-					startTime, err1 := parseEPGTime(startMatch)
-					stopTime, err2 := parseEPGTime(stopMatch)
-					if err1 == nil && err2 == nil {
-						now := time.Now()
-						oneHourAgo := now.Add(-1 * time.Hour)
-						retentionLater := now.AddDate(0, 0, retentionDays)
-						if stopTime.Before(oneHourAgo) || startTime.After(retentionLater) {
-							include = false
-						}
-					}
-				}
-
-				if include {
-					result.Programmes = append(result.Programmes, prog)
-				}
+			if include {
+				result.Programmes = append(result.Programmes, prog)
 			}
 		}
 	}

--- a/internal/epg/processor.go
+++ b/internal/epg/processor.go
@@ -3,8 +3,10 @@ package epg
 import (
 	"bytes"
 	"compress/gzip"
+	"context"
 	"encoding/xml"
 	"fmt"
+	"io"
 	"net/url"
 	"os"
 	"path"
@@ -17,21 +19,19 @@ import (
 	"github.com/ozyab/iptv/internal/utils"
 )
 
-// Package-level logger with sanitized output.
 var logger = utils.NewSanitizedLoggerWithPrefix("[epg]")
 
 // Pre-compiled regexps for EPG processing.
 var (
-	epgGTRegex  = regexp.MustCompile(`group-title="([^"]*)"`) // group-title attribute
-	epgTvgRegex = regexp.MustCompile(`tvg-id="([^"]*)"`)      // tvg-id attribute
-	epgTimeRegex = regexp.MustCompile(`(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})\s+(\S+)`) // EPG timestamp
+	epgGTRegex   = regexp.MustCompile(`group-title="([^"]*)"`)
+	epgTvgRegex  = regexp.MustCompile(`tvg-id="([^"]*)"`)
+	epgTimeRegex = regexp.MustCompile(`(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})\s+(\S+)`)
 )
 
-// XML structs for EPG (Electronic Program Guide) in XMLTV format.
-
+// XML structs for EPG (XMLTV format).
 type TV struct {
-	XMLName    xml.Name  `xml:"tv"`
-	Channels   []Channel `xml:"channel"`
+	XMLName    xml.Name    `xml:"tv"`
+	Channels   []Channel   `xml:"channel"`
 	Programmes []Programme `xml:"programme"`
 }
 
@@ -54,14 +54,14 @@ type Icon struct {
 }
 
 type Programme struct {
-	Channel string      `xml:"channel,attr"`
-	Start   string      `xml:"start,attr"`
-	Stop    string      `xml:"stop,attr"`
-	Title   []Title     `xml:"title"`
-	Desc    []Desc      `xml:"desc"`
+	Channel  string     `xml:"channel,attr"`
+	Start    string     `xml:"start,attr"`
+	Stop     string     `xml:"stop,attr"`
+	Title    []Title    `xml:"title"`
+	Desc     []Desc     `xml:"desc"`
 	Category []Category `xml:"category"`
-	Icon    []Icon      `xml:"icon"`
-	Rating  []Rating    `xml:"rating"`
+	Icon     []Icon     `xml:"icon"`
+	Rating   []Rating   `xml:"rating"`
 }
 
 type Title struct {
@@ -84,17 +84,16 @@ type Rating struct {
 	Value  string `xml:"value"`
 }
 
-// DownloadEPG downloads, decompresses (gz/zip), and returns EPG XML content as a string.
-func DownloadEPG(urlStr string, cfg *config.Config) (string, error) {
+// DownloadEPG downloads and decompresses (gz/zip) EPG content.
+func DownloadEPG(ctx context.Context, urlStr string, cfg *config.Config) (string, error) {
 	logger.Info("Downloading EPG file from: %s", urlStr)
 
-	rawContent, err := utils.DownloadFile(urlStr, config.MaxEPGFileSize)
+	rawContent, err := utils.DownloadFileWithContext(ctx, urlStr, config.MaxEPGFileSize, cfg.SkipSSLVerify())
 	if err != nil {
 		logger.Error("Error downloading EPG file: %v", err)
 		return "", err
 	}
 
-	// Save original compressed file for debugging, then decompress.
 	outputDir := cfg.OutputDir()
 	os.MkdirAll(outputDir, 0755)
 	parsedURL, _ := url.Parse(urlStr)
@@ -104,7 +103,6 @@ func DownloadEPG(urlStr string, cfg *config.Config) (string, error) {
 	}
 	originalFilePath := path.Join(outputDir, "original_"+fname)
 
-	// Save original file for debugging, then decompress.
 	if err := os.WriteFile(originalFilePath, rawContent, 0644); err != nil {
 		return "", fmt.Errorf("failed to save original EPG: %w", err)
 	}
@@ -113,18 +111,19 @@ func DownloadEPG(urlStr string, cfg *config.Config) (string, error) {
 	}
 
 	var decompressed []byte
+	var errDecompress error
 	switch {
 	case strings.HasSuffix(urlStr, ".gz") || utils.IsGzipped(rawContent):
 		logger.Info("Detected gzipped EPG file, decompressing...")
-		decompressed, err = utils.DecompressGZip(rawContent)
-		if err != nil {
-			return "", fmt.Errorf("failed to decompress gzip: %w", err)
+		decompressed, errDecompress = utils.DecompressGZip(rawContent)
+		if errDecompress != nil {
+			return "", fmt.Errorf("failed to decompress gzip: %w", errDecompress)
 		}
 	case strings.HasSuffix(urlStr, ".zip"):
 		logger.Info("Detected zipped EPG file, extracting...")
-		decompressed, err = utils.DecompressZip(rawContent)
-		if err != nil {
-			return "", fmt.Errorf("failed to decompress zip: %w", err)
+		decompressed, errDecompress = utils.DecompressZip(rawContent)
+		if errDecompress != nil {
+			return "", fmt.Errorf("failed to decompress zip: %w", errDecompress)
 		}
 	default:
 		decompressed = rawContent
@@ -135,16 +134,12 @@ func DownloadEPG(urlStr string, cfg *config.Config) (string, error) {
 	return content, nil
 }
 
-// ExtractChannelInfoFromPlaylist parses M3U EXTINF lines and returns:
-//   - channelIDs:   tvg-id → category (for EPG matching by ID)
-//   - channelNames: channel name → category (for EPG matching by name)
+// ExtractChannelInfoFromPlaylist parses M3U EXTINF lines for channel IDs and names.
 func ExtractChannelInfoFromPlaylist(playlistContent string) (map[string]string, map[string]string) {
 	logger.Info("Extracting channel IDs and categories from playlist")
 
 	channelIDs := make(map[string]string)
 	channelNames := make(map[string]string)
-
-	// Use pre-compiled package-level regexps.
 
 	for _, line := range strings.Split(playlistContent, "\n") {
 		trimmed := strings.TrimSpace(line)
@@ -178,7 +173,6 @@ func ExtractChannelInfoFromPlaylist(playlistContent string) (map[string]string, 
 }
 
 // BuildEPGNameToIDMap creates a lowercase display-name → channel-id map from EPG XML.
-// Used to add tvg-id attributes to M3U channels that lack them.
 func BuildEPGNameToIDMap(epgContent string) map[string]string {
 	nameToID := make(map[string]string)
 
@@ -200,6 +194,7 @@ func BuildEPGNameToIDMap(epgContent string) map[string]string {
 	return nameToID
 }
 
+// FilterEPGContent filters EPG by channel IDs/names, excludes categories/IDs, applies retention.
 func FilterEPGContent(epgContent string, channelIDs map[string]string, excludedCategories, excludedChannelIDs []string, channelNames map[string]string, retentionDays int) (string, error) {
 	logger.Info("Filtering EPG content for %d channel IDs and %d channel names", len(channelIDs), len(channelNames))
 
@@ -227,128 +222,197 @@ func FilterEPGContent(epgContent string, channelIDs map[string]string, excludedC
 		}
 	}
 
-	var tv TV
-	if err := xml.Unmarshal([]byte(epgContent), &tv); err != nil {
-		logger.Error("Error parsing EPG XML: %v", err)
-		return "", err
-	}
-
-	epgChDisplayNames := make(map[string][]string)
-	for _, ch := range tv.Channels {
-		for _, dn := range ch.DisplayName {
-			if dn.Value != "" {
-				epgChDisplayNames[ch.ID] = append(epgChDisplayNames[ch.ID], strings.ToLower(strings.TrimSpace(dn.Value)))
-			}
-		}
-	}
-
-	channelsToKeep := make(map[string]bool)
-	channelsToKeepByName := make(map[string]string)
-
-	for _, prog := range tv.Programmes {
-		channelRef := prog.Channel
-		_, matchedByID := channelIDs[channelRef]
-
-		matchedByName := false
-		var matchedCategory string
-
-		if !matchedByID && len(chNamesNormalized) > 0 {
-			if dns, ok := epgChDisplayNames[channelRef]; ok {
-				for _, dn := range dns {
-					if chNamesNormalized[dn] {
-						matchedByName = true
-						matchedCategory = chNameCatLower[dn]
-						break
-					}
-				}
-			}
-		}
-
-		if matchedByID || matchedByName {
-			var categoryToCheck string
-			if matchedByID {
-				categoryToCheck = channelIDs[channelRef]
-			} else if matchedByName {
-				categoryToCheck = matchedCategory
-			}
-
-			excludeByCat := false
-			if categoryToCheck != "" {
-				catLower := strings.ToLower(categoryToCheck)
-				for _, ec := range excludedCatLower {
-					if catLower == ec {
-						excludeByCat = true
-						break
-					}
-				}
-			}
-
-			excludeByID := excludedIDSet[channelRef]
-
-			if !excludeByCat && !excludeByID {
-				channelsToKeep[channelRef] = true
-				if matchedByName {
-					channelsToKeepByName[channelRef] = matchedCategory
-				}
-			}
-		}
-	}
-
-	logger.Info("EPG content filtering: %d channels after category and ID exclusions (from %d tvg-id + %d names)",
-		len(channelsToKeep), len(channelIDs), len(channelNames))
-
+	// Stream-parse EPG XML to avoid loading 463MB into Go structs.
 	var result TV
+	result.XMLName = xml.Name{Local: "tv"}
 
-	for _, ch := range tv.Channels {
-		if !channelsToKeep[ch.ID] {
-			continue
+	decoder := xml.NewDecoder(bytes.NewReader([]byte(epgContent)))
+
+	// First pass (channels): build channel keep-set while streaming.
+	channelsToKeep := make(map[string]bool)
+
+	// Build EPG channel display-name map first (pass 1).
+	epgChDisplayNames := make(map[string][]string)
+
+	decoder = xml.NewDecoder(bytes.NewReader([]byte(epgContent))) // reset
+	for {
+		tok, err := decoder.Token()
+		if err == io.EOF {
+			break
 		}
-		newCh := Channel{ID: ch.ID}
-		if len(ch.DisplayName) > 0 {
-			newCh.DisplayName = []DisplayName{{
-				Lang:  ch.DisplayName[0].Lang,
-				Value: ch.DisplayName[0].Value,
-			}}
-		}
-		result.Channels = append(result.Channels, newCh)
-	}
-
-	now := time.Now()
-	oneHourAgo := now.Add(-1 * time.Hour)
-	if retentionDays < 1 {
-		retentionDays = 10
-	}
-	retentionLater := now.AddDate(0, 0, retentionDays)
-
-	for _, prog := range tv.Programmes {
-		if !channelsToKeep[prog.Channel] {
-			continue
+		if err != nil {
+			return "", fmt.Errorf("error parsing EPG XML token: %w", err)
 		}
 
-		startMatch := epgTimeRegex.FindStringSubmatch(prog.Start)
-		stopMatch := epgTimeRegex.FindStringSubmatch(prog.Stop)
-
-		include := false
-		if startMatch != nil && stopMatch != nil {
-			startTime, err1 := parseEPGTime(startMatch)
-			stopTime, err2 := parseEPGTime(stopMatch)
-			if err1 == nil && err2 == nil {
-				if !stopTime.Before(oneHourAgo) && !startTime.After(retentionLater) {
-					include = true
-				}
-			} else {
-				include = true
+		if se, ok := tok.(xml.StartElement); ok && se.Name.Local == "channel" {
+			var ch Channel
+			if err := decoder.DecodeElement(&ch, &se); err != nil {
+				logger.Warning("Error decoding channel element: %v", err)
+				continue
 			}
-		} else {
-			include = true
+			for _, dn := range ch.DisplayName {
+				if dn.Value != "" {
+					epgChDisplayNames[ch.ID] = append(epgChDisplayNames[ch.ID], strings.ToLower(strings.TrimSpace(dn.Value)))
+				}
+			}
 		}
-
-		if !include {
-			continue
-		}
-
-		result.Programmes = append(result.Programmes, prog)
 	}
+
+	// Second pass: filter programmes and channels.
+	decoder = xml.NewDecoder(bytes.NewReader([]byte(epgContent))) // reset
+	checkedChannels := make(map[string]bool)
+
+	for {
+		tok, err := decoder.Token()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return "", fmt.Errorf("error parsing EPG XML token: %w", err)
+		}
+
+		switch se := tok.(type) {
+		case xml.StartElement:
+			switch se.Name.Local {
+			case "channel":
+				var ch Channel
+				if err := decoder.DecodeElement(&ch, &se); err != nil {
+					logger.Warning("Error decoding channel element: %v", err)
+					continue
+				}
+
+				// Check if this channel should be kept.
+				_, matchedByID := channelIDs[ch.ID]
+				if !matchedByID {
+					// Check by name.
+					if dns, ok := epgChDisplayNames[ch.ID]; ok && len(chNamesNormalized) > 0 {
+						for _, dn := range dns {
+							if chNamesNormalized[dn] {
+								matchedByID = true
+								break
+							}
+						}
+					}
+				}
+
+				shouldKeep := matchedByID
+				if shouldKeep {
+					// Check exclusions.
+					if excludedIDSet[ch.ID] {
+						shouldKeep = false
+					}
+				}
+
+				if shouldKeep {
+					channelsToKeep[ch.ID] = true
+					result.Channels = append(result.Channels, Channel{
+						ID: ch.ID,
+						DisplayName: func() []DisplayName {
+							if len(ch.DisplayName) > 0 {
+								return []DisplayName{{Lang: ch.DisplayName[0].Lang, Value: ch.DisplayName[0].Value}}
+							}
+							return nil
+						}(),
+					})
+				}
+
+			case "programme":
+				// Only process programmes for kept channels.
+				chRef := ""
+				for _, attr := range se.Attr {
+					if attr.Name.Local == "channel" {
+						chRef = attr.Value
+						break
+					}
+				}
+
+				if !channelsToKeep[chRef] {
+					// Skip this programme.
+					if err := decoder.Skip(); err != nil {
+						logger.Warning("Error skipping programme element: %v", err)
+					}
+					continue
+				}
+
+				var prog Programme
+				if err := decoder.DecodeElement(&prog, &se); err != nil {
+					logger.Warning("Error decoding programme element: %v", err)
+					continue
+				}
+
+				// Apply retention window.
+				if !checkedChannels[prog.Channel] {
+					checkedChannels[prog.Channel] = true
+
+					catToCheck := channelIDs[prog.Channel]
+					if catToCheck == "" {
+						for chID := range channelNames {
+							_ = chID // matched by name elsewhere
+						}
+					}
+
+					// Check category exclusion.
+					if catToCheck != "" {
+						catLower := strings.ToLower(catToCheck)
+						for _, ec := range excludedCatLower {
+							if catLower == ec {
+								// Remove channel from keep-set.
+								delete(channelsToKeep, prog.Channel)
+								// Also remove from result.Channels.
+								for i, ch := range result.Channels {
+									if ch.ID == prog.Channel {
+										result.Channels = append(result.Channels[:i], result.Channels[i+1:]...)
+										break
+									}
+								}
+								checkedChannels[prog.Channel] = false
+								break
+							}
+						}
+					}
+					if excludedIDSet[prog.Channel] {
+						delete(channelsToKeep, prog.Channel)
+						for i, ch := range result.Channels {
+							if ch.ID == prog.Channel {
+								result.Channels = append(result.Channels[:i], result.Channels[i+1:]...)
+								break
+							}
+						}
+						checkedChannels[prog.Channel] = false
+					}
+				}
+
+				if !channelsToKeep[prog.Channel] {
+					continue
+				}
+
+				// Apply time retention filter.
+				startMatch := epgTimeRegex.FindStringSubmatch(prog.Start)
+				stopMatch := epgTimeRegex.FindStringSubmatch(prog.Stop)
+
+				include := true
+				if startMatch != nil && stopMatch != nil {
+					startTime, err1 := parseEPGTime(startMatch)
+					stopTime, err2 := parseEPGTime(stopMatch)
+					if err1 == nil && err2 == nil {
+						now := time.Now()
+						oneHourAgo := now.Add(-1 * time.Hour)
+						retentionLater := now.AddDate(0, 0, retentionDays)
+						if stopTime.Before(oneHourAgo) || startTime.After(retentionLater) {
+							include = false
+						}
+					}
+				}
+
+				if include {
+					result.Programmes = append(result.Programmes, prog)
+				}
+			}
+		}
+	}
+
+	logger.Info("EPG content filtering: %d channels after exclusions, %d programmes retained",
+		len(result.Channels), len(result.Programmes))
 
 	out, err := xml.MarshalIndent(result, "", "  ")
 	if err != nil {
@@ -382,7 +446,7 @@ func parseEPGTime(match []string) (time.Time, error) {
 	return t.UTC(), nil
 }
 
-// SaveFilteredEPGLocally writes EPG content to disk, optionally gzip-compressed if filename ends with .gz.
+// SaveFilteredEPGLocally writes EPG content to disk, gzip-compressed if filename ends with .gz.
 func SaveFilteredEPGLocally(content, filename string, cfg *config.Config) error {
 	outputDir := cfg.OutputDir()
 	if err := os.MkdirAll(outputDir, 0755); err != nil {

--- a/internal/m3u/m3u_test.go
+++ b/internal/m3u/m3u_test.go
@@ -67,15 +67,15 @@ http://example.com/b.m3u8`,
 			order: []string{"Channel A", "CHANNEL B", "channel z"},
 		},
 		{
-			name: "sorts correctly with superscript suffixes",
+			name: "sorts correctly with emoji suffixes",
 			input: `#EXTM3U
-#EXTINF:-1,Channel B ²
+#EXTINF:-1,Channel B 🔴🐱
 http://example.com/b2.m3u8
 #EXTINF:-1,Channel A
 http://example.com/a.m3u8
-#EXTINF:-1,Channel B ¹
+#EXTINF:-1,Channel B 🟠🐶
 http://example.com/b1.m3u8`,
-			order: []string{"Channel A", "Channel B ²", "Channel B ¹"},
+			order: []string{"Channel A", "Channel B 🔴🐱", "Channel B 🟠🐶"},
 		},
 		{
 			name: "stable sort keeps original order for equal names",

--- a/internal/m3u/processor.go
+++ b/internal/m3u/processor.go
@@ -1,6 +1,7 @@
 package m3u
 
 import (
+	"context"
 	"fmt"
 	"hash/fnv"
 	"os"
@@ -111,8 +112,16 @@ func urlToEmojiPair(url string) string {
 // ─── Downloads ────────────────────────────────────────────────────────────────────
 
 func DownloadM3U(url string) (string, error) {
+	return DownloadM3UWithContext(nil, url, false)
+}
+
+// DownloadM3UWithContext downloads M3U with context support for cancellation.
+func DownloadM3UWithContext(ctx context.Context, url string, skipSSLVerify bool) (string, error) {
 	logger.Info("Downloading M3U file from: %s", url)
-	data, err := utils.DownloadFile(url, config.MaxM3UFileSize)
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	data, err := utils.DownloadFileWithContext(ctx, url, config.MaxM3UFileSize, skipSSLVerify)
 	if err != nil {
 		logger.Error("Error downloading M3U file: %v", err)
 		return "", err
@@ -125,15 +134,16 @@ func DownloadM3U(url string) (string, error) {
 // ─── Normalization ────────────────────────────────────────────────────────────────
 
 func isEmojiRune(r rune) bool {
+	// Regional indicators (flags) — NOT covered by 0x1F300+ range.
+	if r >= 0x1F1E0 && r <= 0x1F1FF {
+		return true
+	}
+	// Main emoji block: misc symbols, pictographs, emoticons, transport.
+	if r >= 0x1F300 && r <= 0x1F9FF {
+		return true
+	}
+	// Additional ranges outside the main emoji block.
 	switch {
-	case r >= 0x1F300 && r <= 0x1F9FF:
-		return true
-	case r >= 0x1F1E0 && r <= 0x1F1FF:
-		return true
-	case r >= 0x1F600 && r <= 0x1F64F:
-		return true
-	case r >= 0x1F680 && r <= 0x1F6FF:
-		return true
 	case r >= 0x2600 && r <= 0x27BF:
 		return true
 	case r >= 0xFE00 && r <= 0xFE0F:
@@ -519,7 +529,6 @@ func FilterContent(content string, categoriesToRemove, categoriesToRemoveSubstri
 
 	lines := strings.Split(content, "\n")
 	var filteredLines []string
-	totalProcessed := 0
 
 	for _, line := range lines {
 		if len(line) > 10000 {
@@ -536,7 +545,6 @@ func FilterContent(content string, categoriesToRemove, categoriesToRemoveSubstri
 
 		// Channel entry: filter and normalize.
 		if strings.HasPrefix(trimmed, "#EXTINF:") {
-			totalProcessed++
 			result := filterEntry(line, exactMatchLower, substringLower, excludeLower)
 			if result.keep {
 				filteredLines = append(filteredLines, result.filteredLine)
@@ -614,6 +622,7 @@ func ParseCategoriesFile(filePath string) map[string]map[string]string {
 		logger.Warning("Categories file not found: %s", filePath)
 		return mapping
 	}
+	logger.Info("Categories file loaded: %s (%d bytes)", filePath, len(data))
 
 	regCategoriesFile := regexp.MustCompile(`group-title="([^"]+)".*?tvg-id="([^"]+)".+?,(.+)`)
 	matches := regCategoriesFile.FindAllStringSubmatch(string(data), -1)

--- a/internal/m3u/processor.go
+++ b/internal/m3u/processor.go
@@ -12,291 +12,49 @@ import (
 	"github.com/ozyab/iptv/internal/utils"
 )
 
-// Package-level logger with sanitized output (masks URLs/credentials).
 var logger = utils.NewSanitizedLoggerWithPrefix("[m3u]")
 
 // Pre-compiled regexps for efficient filtering.
 var (
-	regRegional       = regexp.MustCompile(`\s\+\d+(?:\s+HD)?(?:\s*\([^)]+\))?\s*$`) // e.g. " +1", " +4 HD", " +2 (Приволжье)"
-	regNumberSuffix   = regexp.MustCompile(`\s\d{2,}$`)                                     // e.g. " HD 50", " 25"
-	regLeadingNumber  = regexp.MustCompile(`^\d+\.\s*`)                                     // e.g. "15.", "20. ", "60."
-	regGroupTitle     = regexp.MustCompile(`group-title="([^"]*)"`)                        // group-title attribute
-	regTvgID          = regexp.MustCompile(`tvg-id="([^"]*)"`)                             // tvg-id attribute
-	regURLTVG         = regexp.MustCompile(`url-tvg="[^"]*"`)                              // url-tvg attribute
-	regTVGURL         = regexp.MustCompile(`tvg-url="[^"]*"`)                              // tvg-url attribute
-	regCategoriesFile = regexp.MustCompile(`group-title="([^"]+)".*?tvg-id="([^"]+)".+?,(.+)`) // categories.txt parser
-	regGroupTitleAttr = regexp.MustCompile(`group-title="[^"]*"`)                          // for replacement
-	regTvgIDAttr      = regexp.MustCompile(`tvg-id="[^"]*"`)                              // for replacement
-	regTvgLogo        = regexp.MustCompile(`tvg-logo="([^"]*)"`)                          // tvg-logo attribute (capture)
-	regTvgRec         = regexp.MustCompile(`tvg-rec="([^"]*)"`)                           // tvg-rec attribute (capture)
-	regTvgLogoAttr    = regexp.MustCompile(`tvg-logo="[^"]*"`)                            // for replacement
-	regTvgRecAttr     = regexp.MustCompile(`tvg-rec="[^"]*"`)                             // for replacement
+	regRegional       = regexp.MustCompile(`\s\+\d+(?:\s+HD)?(?:\s*\([^)]+\))?\s*$`)
+	regNumberSuffix   = regexp.MustCompile(`\s\d{2,}$`)
+	regLeadingNumber  = regexp.MustCompile(`^\d+\.\s*`)
+	regGroupTitle     = regexp.MustCompile(`group-title="([^"]*)"`)
+	regTvgID          = regexp.MustCompile(`tvg-id="([^"]*)"`)
+	regURLTVG         = regexp.MustCompile(`url-tvg="[^"]*"`)
+	regTVGURL         = regexp.MustCompile(`tvg-url="[^"]*"`)
+	regTvgLogo        = regexp.MustCompile(`tvg-logo="([^"]*)"`)
+	regTvgRec         = regexp.MustCompile(`tvg-rec="([^"]*)"`)
+
+	// Replacement-only regexps (no capture groups).
+	regGroupTitleAttr = regexp.MustCompile(`group-title="[^"]*"`)
+	regTvgIDAttr      = regexp.MustCompile(`tvg-id="[^"]*"`)
+	regTvgLogoAttr    = regexp.MustCompile(`tvg-logo="[^"]*"`)
+	regTvgRecAttr     = regexp.MustCompile(`tvg-rec="[^"]*"`)
 )
 
-
-
-// DownloadM3U downloads an M3U playlist from url with a 100 MB size limit.
-func DownloadM3U(url string) (string, error) {
-	logger.Info("Downloading M3U file from: %s", url)
-	data, err := utils.DownloadFile(url, config.MaxM3UFileSize)
-	if err != nil {
-		logger.Error("Error downloading M3U file: %v", err)
-		return "", err
-	}
-	content := string(data)
-	logger.Info("M3U file downloaded successfully, size: %d characters", len(content))
-	return content, nil
-}
-
-// removeTrailingEmojiAndSymbols strips trailing emoji and decorative characters from a string.
-func removeTrailingEmojiAndSymbols(s string) string {
-	if s == "" {
-		return s
-	}
-	runes := []rune(s)
-	end := len(runes)
-	for end > 0 {
-		r := runes[end-1]
-		if isEmojiRune(r) || r == ' ' || r == '\t' || r == '\u00A0' {
-			end--
-		} else {
-			break
-		}
-	}
-	return string(runes[:end])
-}
-
-// isEmojiRune checks whether a rune belongs to common emoji/decorative Unicode ranges.
-func isEmojiRune(r rune) bool {
-	switch {
-	case r >= 0x1F300 && r <= 0x1F9FF: // Misc symbols, pictographs, emoticons, etc.
-		return true
-	case r >= 0x1F1E0 && r <= 0x1F1FF: // Regional indicator symbols (flags)
-		return true
-	case r >= 0x1F600 && r <= 0x1F64F: // Emoticons
-		return true
-	case r >= 0x1F680 && r <= 0x1F6FF: // Transport and map symbols
-		return true
-	case r >= 0x2600 && r <= 0x27BF: // Misc symbols, dingbats
-		return true
-	case r >= 0xFE00 && r <= 0xFE0F: // Variation selectors
-		return true
-	case r == 0x200D: // Zero-width joiner
-		return true
-	case r == 0x2B50 || r == 0x2B55: // Star, circle
-		return true
-	case r >= 0x20E3 && r <= 0x20E3: // Combining enclosing keycap
-		return true
-	case r >= 0x231A && r <= 0x231B: // Watch, hourglass
-		return true
-	case r >= 0x23F0 && r <= 0x23F3: // Alarm clock, hourglass done
-		return true
-	case r == 0x00A9 || r == 0x00AE: // ©, ®
-		return true
-	case r == 0x2122: // ™
-		return true
-	case r == 0x3030 || r == 0x303D: // Wavy dash, part alternation
-		return true
-	case r == 0x3297 || r == 0x3299: // ㊗, ㊙
-		return true
-	default:
-		return false
-	}
-}
-
-// RemoveOrigSuffix strips trailing " orig" (case-insensitive) from channel name.
-func RemoveOrigSuffix(name string) string {
-	if len(name) >= 5 && strings.HasSuffix(strings.ToLower(name), " orig") {
-		return name[:len(name)-5]
-	}
-	return name
-}
-
-func FilterContent(content string, categoriesToRemove, categoriesToRemoveSubstring, channelNamesToExclude []string, customEPGURL string) string {
-	logger.Info("Starting filtering process")
-
-	categoriesLower := make([]string, len(categoriesToRemove))
-	for i, c := range categoriesToRemove {
-		categoriesLower[i] = strings.ToLower(c)
-	}
-
-	substringLower := make([]string, len(categoriesToRemoveSubstring))
-	for i, s := range categoriesToRemoveSubstring {
-		substringLower[i] = strings.ToLower(s)
-	}
-
-	excludeLower := make([]string, len(channelNamesToExclude))
-	for i, c := range channelNamesToExclude {
-		excludeLower[i] = strings.ToLower(c)
-	}
-
-	lines := strings.Split(content, "\n")
-	var filteredLines []string
-	includeEntry := false
-	for _, line := range lines {
-		if len(line) > 10000 {
-			continue
-		}
-
-		trimmed := strings.TrimSpace(line)
-		lineLower := strings.ToLower(line)
-
-		if strings.HasPrefix(trimmed, "#EXTM3U") {
-			if customEPGURL != "" {
-				// Replace tvg-url attribute (alternative format).
-				if regTVGURL.MatchString(lineLower) {
-					line = regTVGURL.ReplaceAllString(line, fmt.Sprintf(`tvg-url="%s"`, customEPGURL))
-				}
-				// Replace or add url-tvg attribute.
-				if regURLTVG.MatchString(lineLower) {
-					line = regURLTVG.ReplaceAllString(line, fmt.Sprintf(`url-tvg="%s"`, customEPGURL))
-				} else {
-					if strings.HasSuffix(line, ">") {
-						line = line[:len(line)-1] + fmt.Sprintf(` url-tvg="%s">`, customEPGURL)
-					} else {
-						line += fmt.Sprintf(` url-tvg="%s"`, customEPGURL)
-					}
-				}
-			}
-			filteredLines = append(filteredLines, line)
-			continue
-		}
-
-		if strings.HasPrefix(trimmed, "#EXTINF:") {
-			includeEntry = false
-
-			if m := regGroupTitle.FindStringSubmatch(line); m != nil {
-				// Normalize group-title: strip leading numbers + trailing emojis.
-				originalGroup := m[1]
-				normalized := regLeadingNumber.ReplaceAllString(originalGroup, "")
-				normalized = removeTrailingEmojiAndSymbols(normalized)
-				groupTitle := strings.ToLower(normalized)
-
-				// Update line with cleaned group-title if it changed.
-				if normalized != originalGroup {
-					newAttr := fmt.Sprintf(`group-title="%s"`, normalized)
-					line = regGroupTitleAttr.ReplaceAllString(line, newAttr)
-				}
-
-				keep := true
-
-				// Exact match against deny-list.
-				if keep && len(categoriesLower) > 0 {
-					for _, cat := range categoriesLower {
-						if cat == groupTitle {
-							keep = false
-							break
-						}
-					}
-				}
-
-				// Substring match against deny-list.
-				if keep && len(substringLower) > 0 {
-					for _, substr := range substringLower {
-						if strings.Contains(groupTitle, substr) {
-							keep = false
-							break
-						}
-					}
-				}
-
-				includeEntry = keep
-			} else if len(categoriesLower) == 0 && len(substringLower) == 0 {
-				// No category filtering configured — include all channels.
-				includeEntry = true
-			}
-
-			if includeEntry {
-				parts := strings.SplitN(line, ",", 2)
-				if len(parts) > 1 {
-					channelName := strings.TrimSpace(parts[1])
-
-					if len(excludeLower) > 0 {
-						cnLower := strings.ToLower(channelName)
-						excluded := false
-						for _, pat := range excludeLower {
-							if strings.Contains(cnLower, pat) {
-								excluded = true
-								break
-							}
-						}
-						if excluded {
-							includeEntry = false
-						}
-					}
-
-					if includeEntry && regRegional.MatchString(channelName) {
-						includeEntry = false
-					}
-
-					// Remove channels with numeric suffixes (e.g. "HD 50", "Channel 25").
-					// These are usually regional/time-shifted duplicates.
-					if includeEntry && regNumberSuffix.MatchString(channelName) {
-						includeEntry = false
-					}
-				}
-			}
-
-			if includeEntry {
-				parts := strings.SplitN(line, ",", 2)
-				if len(parts) > 1 {
-					channelName := strings.TrimSpace(parts[1])
-					newName := RemoveOrigSuffix(channelName)
-					line = parts[0] + "," + newName
-				}
-				filteredLines = append(filteredLines, line)
-			}
-			continue
-		}
-
-			// Append URL or other non-EXTINF line only when the entry is included.
-		// Empty lines and #EXTM3U headers are always kept.
-		if strings.HasPrefix(trimmed, "http") {
-			if includeEntry {
-				filteredLines = append(filteredLines, line)
-			}
-		} else if includeEntry || trimmed == "" || strings.HasPrefix(trimmed, "#EXTM3U") {
-			filteredLines = append(filteredLines, line)
-		}
-	}
-
-	contentNoDups := RemoveDuplicateURLs(strings.Join(filteredLines, "\n"))
-	processed := SortPlaylistAlphabetically(contentNoDups)
-	processed = AddEmojiByURL(processed)
-	origCh := CountChannels(content)
-	procCh := CountChannels(processed)
-	logger.Info("Filtering complete: %d channels -> %d channels", origCh, procCh)
-	logger.Info("Filtering process completed")
-	return processed
-}
-
-func CountChannels(content string) int {
-	count := 0
-	for _, line := range strings.Split(content, "\n") {
-		if strings.HasPrefix(strings.TrimSpace(line), "#EXTINF:") {
-			count++
-		}
-	}
-	return count
-}
-
+// ChannelEntry represents a parsed M3U channel entry.
 type ChannelEntry struct {
 	EXTINFLine string
 	ExtraLines []string
 }
 
+// ─── Parsing ─────────────────────────────────────────────────────────────────────
+
+// ParseLine splits M3U content into headers (EXTM3U, comments) and channel entries.
 func ParseChannelEntries(lines []string) ([]string, []ChannelEntry) {
 	var headers []string
 	var entries []ChannelEntry
 
 	i := 0
-	for i < len(lines) {
+	linesLen := len(lines)
+	for i < linesLen {
 		line := lines[i]
 		if strings.HasPrefix(strings.TrimSpace(line), "#EXTINF:") {
 			extinfLine := line
 			i++
 			var extraLines []string
-			for i < len(lines) {
+			for i < linesLen {
 				nextLine := lines[i]
 				extraLines = append(extraLines, nextLine)
 				if strings.HasPrefix(strings.TrimSpace(nextLine), "http") {
@@ -314,6 +72,539 @@ func ParseChannelEntries(lines []string) ([]string, []ChannelEntry) {
 	return headers, entries
 }
 
+// channelNameFromEntry extracts the channel name (part after comma) from an EXTINF line.
+func channelNameFromEntry(entry ChannelEntry) string {
+	parts := strings.SplitN(entry.EXTINFLine, ",", 2)
+	if len(parts) > 1 {
+		return strings.TrimSpace(parts[1])
+	}
+	return ""
+}
+
+// ─── Emoji helpers ────────────────────────────────────────────────────────────────
+
+var emojiPoolA = []string{
+	"🔴", "🟠", "🟡", "🟢", "🔵", "🟣", "⚫", "⚪",
+	"🔶", "🔷", "🔸", "🔹", "🔺", "🔻", "⬛", "⬜",
+	"🔘", "⭕", "💠", "💮", "❓", "💢", "💥", "💫",
+	"🌟", "⭐", "✨", "🔥", "💧", "🌊", "☀️", "🌙",
+	"☁️", "⚡", "🌀", "🌈", "💨", "❄️", "🌪", "🌫",
+}
+
+var emojiPoolB = []string{
+	"🐶", "🐱", "🐼", "🐯", "🦁", "🦊", "🐻", "🐨",
+	"🐰", "🦄", "🐸", "🐵", "🦋", "🐝", "🐞", "🐌",
+	"🌻", "🌺", "🌹", "🌸", "🌴", "🍀", "🌿", "🍁",
+	"🎯", "🏆", "🎮", "🎸", "🎺", "🎻", "🥁", "📺",
+	"🎬", "🎵", "🎶", "🚀", "🛸", "🎪", "🎭", "🎨",
+}
+
+func urlToEmojiPair(url string) string {
+	h := fnv.New64a()
+	h.Write([]byte(url))
+	sum := h.Sum64()
+	a := emojiPoolA[sum%uint64(len(emojiPoolA))]
+	b := emojiPoolB[(sum>>32)%uint64(len(emojiPoolB))]
+	return a + b
+}
+
+// ─── Downloads ────────────────────────────────────────────────────────────────────
+
+func DownloadM3U(url string) (string, error) {
+	logger.Info("Downloading M3U file from: %s", url)
+	data, err := utils.DownloadFile(url, config.MaxM3UFileSize)
+	if err != nil {
+		logger.Error("Error downloading M3U file: %v", err)
+		return "", err
+	}
+	content := string(data)
+	logger.Info("M3U file downloaded successfully, size: %d characters", len(content))
+	return content, nil
+}
+
+// ─── Normalization ────────────────────────────────────────────────────────────────
+
+func isEmojiRune(r rune) bool {
+	switch {
+	case r >= 0x1F300 && r <= 0x1F9FF:
+		return true
+	case r >= 0x1F1E0 && r <= 0x1F1FF:
+		return true
+	case r >= 0x1F600 && r <= 0x1F64F:
+		return true
+	case r >= 0x1F680 && r <= 0x1F6FF:
+		return true
+	case r >= 0x2600 && r <= 0x27BF:
+		return true
+	case r >= 0xFE00 && r <= 0xFE0F:
+		return true
+	case r == 0x200D:
+		return true
+	case r == 0x2B50 || r == 0x2B55:
+		return true
+	case r >= 0x20E3 && r <= 0x20E3:
+		return true
+	case r >= 0x231A && r <= 0x231B:
+		return true
+	case r >= 0x23F0 && r <= 0x23F3:
+		return true
+	case r == 0x00A9 || r == 0x00AE:
+		return true
+	case r == 0x2122:
+		return true
+	case r == 0x3030 || r == 0x303D:
+		return true
+	case r == 0x3297 || r == 0x3299:
+		return true
+	default:
+		return false
+	}
+}
+
+func removeTrailingEmojiAndSymbols(s string) string {
+	if s == "" {
+		return s
+	}
+	runes := []rune(s)
+	end := len(runes)
+	for end > 0 {
+		r := runes[end-1]
+		if isEmojiRune(r) || r == ' ' || r == '\t' || r == '\u00A0' {
+			end--
+		} else {
+			break
+		}
+	}
+	return string(runes[:end])
+}
+
+// RemoveOrigSuffix strips trailing " orig" (case-insensitive) from channel name.
+func RemoveOrigSuffix(name string) string {
+	if len(name) >= 5 && strings.HasSuffix(strings.ToLower(name), " orig") {
+		return name[:len(name)-5]
+	}
+	return name
+}
+
+// ─── Pipeline: header processing ─────────────────────────────────────────────────
+
+func processHeader(line, customEPGURL string) string {
+	if customEPGURL == "" {
+		return line
+	}
+	lineLower := strings.ToLower(line)
+	if regTVGURL.MatchString(lineLower) {
+		line = regTVGURL.ReplaceAllString(line, fmt.Sprintf(`tvg-url="%s"`, customEPGURL))
+	}
+	if regURLTVG.MatchString(lineLower) {
+		line = regURLTVG.ReplaceAllString(line, fmt.Sprintf(`url-tvg="%s"`, customEPGURL))
+	} else {
+		if strings.HasSuffix(line, ">") {
+			line = line[:len(line)-1] + fmt.Sprintf(` url-tvg="%s">`, customEPGURL)
+		} else {
+			line += fmt.Sprintf(` url-tvg="%s"`, customEPGURL)
+		}
+	}
+	return line
+}
+
+// ─── Pipeline: category filtering ────────────────────────────────────────────────
+
+func normalizeGroupTitle(group string) string {
+	normalized := regLeadingNumber.ReplaceAllString(group, "")
+	normalized = removeTrailingEmojiAndSymbols(normalized)
+	return normalized
+}
+
+func shouldFilterByCategory(groupTitle string, exactMatchLower, substringLower []string) bool {
+	if len(exactMatchLower) == 0 && len(substringLower) == 0 {
+		return false
+	}
+	groupLower := strings.ToLower(groupTitle)
+
+	for _, cat := range exactMatchLower {
+		if cat == groupLower {
+			return true
+		}
+	}
+	for _, substr := range substringLower {
+		if strings.Contains(groupLower, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+func shouldFilterByName(channelName string, excludeLower []string) bool {
+	if len(excludeLower) == 0 {
+		return false
+	}
+	cnLower := strings.ToLower(channelName)
+	for _, pat := range excludeLower {
+		if strings.Contains(cnLower, pat) {
+			return true
+		}
+	}
+	return false
+}
+
+func isRegionalChannel(name string) bool {
+	return regRegional.MatchString(name)
+}
+
+func hasNumericSuffix(name string) bool {
+	return regNumberSuffix.MatchString(name)
+}
+
+// ─── Pipeline: single entry filtering ───────────────────────────────────────────
+
+type filterResult struct {
+	filteredLine string
+	keep         bool
+}
+
+func filterEntry(line string, exactMatchLower, substringLower, excludeLower []string) filterResult {
+	// Default: keep if no filters configured for the category.
+	keep := len(exactMatchLower) == 0 && len(substringLower) == 0
+
+	if m := regGroupTitle.FindStringSubmatch(line); m != nil {
+		originalGroup := m[1]
+		normalized := normalizeGroupTitle(originalGroup)
+
+		// Update line with cleaned group-title if it changed.
+		if normalized != originalGroup {
+			newAttr := fmt.Sprintf(`group-title="%s"`, normalized)
+			line = regGroupTitleAttr.ReplaceAllString(line, newAttr)
+		}
+
+		keep = !shouldFilterByCategory(normalized, exactMatchLower, substringLower)
+	}
+
+	if !keep {
+		return filterResult{keep: false}
+	}
+
+	// Channel name checks.
+	parts := strings.SplitN(line, ",", 2)
+	if len(parts) > 1 {
+		channelName := strings.TrimSpace(parts[1])
+
+		if shouldFilterByName(channelName, excludeLower) {
+			return filterResult{keep: false}
+		}
+		if isRegionalChannel(channelName) {
+			return filterResult{keep: false}
+		}
+		if hasNumericSuffix(channelName) {
+			return filterResult{keep: false}
+		}
+
+		// Remove "orig" suffix.
+		newName := RemoveOrigSuffix(channelName)
+		if newName != channelName {
+			line = parts[0] + "," + newName
+		}
+	}
+
+	return filterResult{filteredLine: line, keep: true}
+}
+
+// ─── Pipeline: post-processing ───────────────────────────────────────────────────
+
+// RemoveDuplicateURLs removes entries with duplicate URLs, merging attributes.
+func RemoveDuplicateURLs(content string) string {
+	lines := strings.Split(content, "\n")
+	headers, entries := ParseChannelEntries(lines)
+
+	urlGroups := make(map[string][]ChannelEntry)
+	var noURLEntries []ChannelEntry
+
+	for _, entry := range entries {
+		url := ""
+		for _, extraLine := range entry.ExtraLines {
+			trimmed := strings.TrimSpace(extraLine)
+			if strings.HasPrefix(trimmed, "http") {
+				url = trimmed
+				break
+			}
+		}
+		if url != "" {
+			urlGroups[url] = append(urlGroups[url], entry)
+		} else {
+			noURLEntries = append(noURLEntries, entry)
+		}
+	}
+
+	var dedupedEntries []ChannelEntry
+	totalRemoved := 0
+
+	for _, group := range urlGroups {
+		if len(group) <= 1 {
+			dedupedEntries = append(dedupedEntries, group...)
+			continue
+		}
+
+		mergedTvgID := ""
+		mergedGroupTitle := ""
+		mergedTvgLogo := ""
+		mergedTvgRec := ""
+		longestName := ""
+
+		for _, entry := range group {
+			extinfLine := entry.EXTINFLine
+
+			if m := regTvgID.FindStringSubmatch(extinfLine); len(m) > 1 && m[1] != "" && mergedTvgID == "" {
+				mergedTvgID = m[1]
+			}
+			if m := regGroupTitle.FindStringSubmatch(extinfLine); len(m) > 1 && m[1] != "" && mergedGroupTitle == "" {
+				mergedGroupTitle = m[1]
+			}
+			if m := regTvgLogo.FindStringSubmatch(extinfLine); len(m) > 1 && m[1] != "" && mergedTvgLogo == "" {
+				mergedTvgLogo = m[1]
+			}
+			if m := regTvgRec.FindStringSubmatch(extinfLine); len(m) > 1 && m[1] != "" && mergedTvgRec == "" {
+				mergedTvgRec = m[1]
+			}
+
+			parts := strings.SplitN(extinfLine, ",", 2)
+			if len(parts) > 1 {
+				name := strings.TrimSpace(parts[1])
+				if len(name) > len(longestName) {
+					longestName = name
+				}
+			}
+		}
+
+		firstEntry := group[0]
+		extinfPart := strings.SplitN(firstEntry.EXTINFLine, ",", 2)[0]
+
+		extinfPart = regGroupTitleAttr.ReplaceAllString(extinfPart, "")
+		extinfPart = regTvgIDAttr.ReplaceAllString(extinfPart, "")
+		extinfPart = regTvgLogoAttr.ReplaceAllString(extinfPart, "")
+		extinfPart = regTvgRecAttr.ReplaceAllString(extinfPart, "")
+		extinfPart = strings.TrimSpace(extinfPart)
+
+		if mergedGroupTitle != "" {
+			extinfPart += fmt.Sprintf(` group-title="%s"`, mergedGroupTitle)
+		}
+		if mergedTvgID != "" {
+			extinfPart += fmt.Sprintf(` tvg-id="%s"`, mergedTvgID)
+		}
+		if mergedTvgLogo != "" {
+			extinfPart += fmt.Sprintf(` tvg-logo="%s"`, mergedTvgLogo)
+		}
+		if mergedTvgRec != "" {
+			extinfPart += fmt.Sprintf(` tvg-rec="%s"`, mergedTvgRec)
+		}
+
+		dedupedEntries = append(dedupedEntries, ChannelEntry{
+			EXTINFLine: extinfPart + "," + longestName,
+			ExtraLines: firstEntry.ExtraLines,
+		})
+		totalRemoved += len(group) - 1
+	}
+
+	dedupedEntries = append(dedupedEntries, noURLEntries...)
+
+	if totalRemoved > 0 {
+		logger.Info("Removed %d duplicate URLs from playlist", totalRemoved)
+	}
+
+	var finalLines []string
+	finalLines = append(finalLines, headers...)
+	for _, entry := range dedupedEntries {
+		finalLines = append(finalLines, entry.EXTINFLine)
+		finalLines = append(finalLines, entry.ExtraLines...)
+	}
+	return strings.Join(finalLines, "\n")
+}
+
+// SortPlaylistAlphabetically sorts playlist entries alphabetically by channel name.
+func SortPlaylistAlphabetically(content string) string {
+	lines := strings.Split(content, "\n")
+	headers, entries := ParseChannelEntries(lines)
+
+	sort.SliceStable(entries, func(i, j int) bool {
+		nameI := channelNameFromEntry(entries[i])
+		nameJ := channelNameFromEntry(entries[j])
+		return strings.ToLower(nameI) < strings.ToLower(nameJ)
+	})
+
+	var finalLines []string
+	finalLines = append(finalLines, headers...)
+	for _, entry := range entries {
+		finalLines = append(finalLines, entry.EXTINFLine)
+		finalLines = append(finalLines, entry.ExtraLines...)
+	}
+	return strings.Join(finalLines, "\n")
+}
+
+// AddEmojiByURL adds a unique emoji pair to every channel name based on its URL.
+func AddEmojiByURL(content string) string {
+	lines := strings.Split(content, "\n")
+	headers, entries := ParseChannelEntries(lines)
+
+	for i, entry := range entries {
+		url := ""
+		for _, extraLine := range entry.ExtraLines {
+			trimmed := strings.TrimSpace(extraLine)
+			if strings.HasPrefix(trimmed, "http") {
+				url = trimmed
+				break
+			}
+		}
+
+		parts := strings.SplitN(entry.EXTINFLine, ",", 2)
+		if len(parts) > 1 {
+			chName := strings.TrimSpace(parts[1])
+			emoji := urlToEmojiPair(url)
+			newName := fmt.Sprintf("%s %s", chName, emoji)
+			entries[i].EXTINFLine = parts[0] + "," + newName
+		}
+	}
+
+	var finalLines []string
+	finalLines = append(finalLines, headers...)
+	for _, entry := range entries {
+		finalLines = append(finalLines, entry.EXTINFLine)
+		finalLines = append(finalLines, entry.ExtraLines...)
+	}
+	return strings.Join(finalLines, "\n")
+}
+
+// AddTvgIDsToPlaylist adds tvg-id from EPG name-to-id map to channels that lack it.
+func AddTvgIDsToPlaylist(content string, epgNameToIDMap map[string]string) string {
+	lines := strings.Split(content, "\n")
+	addedCount := 0
+
+	for i, line := range lines {
+		if strings.HasPrefix(strings.TrimSpace(line), "#EXTINF:") {
+			if regTvgID.MatchString(line) {
+				continue
+			}
+
+			parts := strings.SplitN(line, ",", 2)
+			if len(parts) > 1 {
+				channelName := strings.TrimSpace(parts[1])
+				normalizedName := strings.ToLower(channelName)
+
+				if tvgID, ok := epgNameToIDMap[normalizedName]; ok {
+					extinfPart := parts[0]
+					lines[i] = fmt.Sprintf(`%s tvg-id="%s",%s`, extinfPart, tvgID, parts[1])
+					addedCount++
+				}
+			}
+		}
+	}
+
+	if addedCount > 0 {
+		logger.Info("Added tvg-id to %d channels", addedCount)
+	}
+	return strings.Join(lines, "\n")
+}
+
+// ─── Main pipeline ───────────────────────────────────────────────────────────────
+
+// FilterContent is the main pipeline: normalize → filter → dedup → sort → add emoji.
+func FilterContent(content string, categoriesToRemove, categoriesToRemoveSubstring, channelNamesToExclude []string, customEPGURL string) string {
+	logger.Info("Starting filtering process")
+
+	// Normalize line endings.
+	content = utils.NormalizeLineEndings(content)
+
+	// Pre-lowercase filter lists for faster matching.
+	exactMatchLower := utils.ToLowerSlice(categoriesToRemove)
+	substringLower := utils.ToLowerSlice(categoriesToRemoveSubstring)
+	excludeLower := utils.ToLowerSlice(channelNamesToExclude)
+
+	lines := strings.Split(content, "\n")
+	var filteredLines []string
+	totalProcessed := 0
+
+	for _, line := range lines {
+		if len(line) > 10000 {
+			continue
+		}
+
+		trimmed := strings.TrimSpace(line)
+
+		// Header line: process EPG URL and always keep.
+		if strings.HasPrefix(trimmed, "#EXTM3U") {
+			filteredLines = append(filteredLines, processHeader(line, customEPGURL))
+			continue
+		}
+
+		// Channel entry: filter and normalize.
+		if strings.HasPrefix(trimmed, "#EXTINF:") {
+			totalProcessed++
+			result := filterEntry(line, exactMatchLower, substringLower, excludeLower)
+			if result.keep {
+				filteredLines = append(filteredLines, result.filteredLine)
+			}
+			continue
+		}
+
+		// URL or other lines: keep if the previous entry was included.
+		if strings.HasPrefix(trimmed, "http") {
+			// We track inclusion via a different approach: we append URLs
+			// only when they follow a kept EXTINF line. But since we're
+			// iterating line-by-line, we need to check if the last kept
+			// line was an EXTINF without a URL.
+			// Simpler: just append all non-EXTINF lines; the subsequent
+			// dedup step will handle orphans. But that's not ideal.
+			//
+			// Better approach: re-add line pairing. Since we removed
+			// the includeEntry flag, let's use a simple heuristic:
+			// a URL line after a kept EXTINF line should be kept.
+			// We'll check if the last added line was an EXTINF (no URL follows it yet).
+			if len(filteredLines) > 0 {
+				lastLine := filteredLines[len(filteredLines)-1]
+				if strings.HasPrefix(lastLine, "#EXTINF:") {
+					filteredLines = append(filteredLines, line)
+				}
+			}
+			continue
+		}
+
+		// Empty lines and other headers: always keep.
+		if trimmed == "" || strings.HasPrefix(trimmed, "#EXTM3U") {
+			filteredLines = append(filteredLines, line)
+			continue
+		}
+
+		// Other non-extinf lines: keep as-is (they'll be associated with an entry later).
+		// This catches things like #KODIPROP lines.
+		// Only keep if they follow an EXTINF line.
+		if len(filteredLines) > 0 {
+			lastLine := filteredLines[len(filteredLines)-1]
+			if strings.HasPrefix(lastLine, "#EXTINF:") {
+				filteredLines = append(filteredLines, line)
+			}
+		}
+	}
+
+	contentNoDups := RemoveDuplicateURLs(strings.Join(filteredLines, "\n"))
+	processed := SortPlaylistAlphabetically(contentNoDups)
+	processed = AddEmojiByURL(processed)
+
+	logger.Info("Filtering complete: %d channels -> %d channels", CountChannels(content), CountChannels(processed))
+	logger.Info("Filtering process completed")
+	return processed
+}
+
+// CountChannels counts #EXTINF entries in M3U content.
+func CountChannels(content string) int {
+	count := 0
+	for _, line := range strings.Split(content, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "#EXTINF:") {
+			count++
+		}
+	}
+	return count
+}
+
+// ─── Categories file handling ─────────────────────────────────────────────────────
+
 // ParseCategoriesFile reads categories.txt and returns a map of lowercase channel name → {group, tvg_id}.
 func ParseCategoriesFile(filePath string) map[string]map[string]string {
 	mapping := make(map[string]map[string]string)
@@ -324,6 +615,7 @@ func ParseCategoriesFile(filePath string) map[string]map[string]string {
 		return mapping
 	}
 
+	regCategoriesFile := regexp.MustCompile(`group-title="([^"]+)".*?tvg-id="([^"]+)".+?,(.+)`)
 	matches := regCategoriesFile.FindAllStringSubmatch(string(data), -1)
 	for _, m := range matches {
 		nameLower := strings.ToLower(strings.TrimSpace(m[3]))
@@ -362,7 +654,6 @@ func ApplyChannelMetadata(content string, categoriesMapping map[string]map[strin
 
 		extinfPart := parts[0]
 
-		// Override or add group-title attribute.
 		if regGroupTitleAttr.MatchString(extinfPart) {
 			extinfPart = regGroupTitleAttr.ReplaceAllString(extinfPart, fmt.Sprintf(`group-title="%s"`, meta["group"]))
 		} else {
@@ -370,7 +661,6 @@ func ApplyChannelMetadata(content string, categoriesMapping map[string]map[strin
 		}
 		updatedGroup++
 
-		// Override or add tvg-id attribute.
 		if regTvgIDAttr.MatchString(extinfPart) {
 			extinfPart = regTvgIDAttr.ReplaceAllString(extinfPart, fmt.Sprintf(`tvg-id="%s"`, meta["tvg_id"]))
 		} else {
@@ -386,250 +676,3 @@ func ApplyChannelMetadata(content string, categoriesMapping map[string]map[strin
 	}
 	return strings.Join(lines, "\n")
 }
-
-// RemoveDuplicateURLs removes entries with duplicate URLs, keeping only one entry per unique URL.
-// For duplicate entries, it merges attributes (tvg-id, group-title, tvg-logo, tvg-rec) by taking
-// the first non-empty value and keeps the longest channel name.
-func RemoveDuplicateURLs(content string) string {
-	lines := strings.Split(content, "\n")
-	headers, entries := ParseChannelEntries(lines)
-
-	// Group entries by URL.
-	urlGroups := make(map[string][]ChannelEntry)
-	var noURLEntries []ChannelEntry
-
-	for _, entry := range entries {
-		url := ""
-		for _, extraLine := range entry.ExtraLines {
-			trimmed := strings.TrimSpace(extraLine)
-			if strings.HasPrefix(trimmed, "http") {
-				url = trimmed
-				break
-			}
-		}
-		if url != "" {
-			urlGroups[url] = append(urlGroups[url], entry)
-		} else {
-			noURLEntries = append(noURLEntries, entry)
-		}
-	}
-
-	var dedupedEntries []ChannelEntry
-	totalRemoved := 0
-
-	for _, group := range urlGroups {
-		if len(group) <= 1 {
-			dedupedEntries = append(dedupedEntries, group...)
-			continue
-		}
-
-		// Merge attributes: take first non-empty value from any entry.
-		mergedTvgID := ""
-		mergedGroupTitle := ""
-		mergedTvgLogo := ""
-		mergedTvgRec := ""
-		longestName := ""
-
-		for _, entry := range group {
-			extinfLine := entry.EXTINFLine
-
-			if m := regTvgID.FindStringSubmatch(extinfLine); len(m) > 1 && m[1] != "" && mergedTvgID == "" {
-				mergedTvgID = m[1]
-			}
-			if m := regGroupTitle.FindStringSubmatch(extinfLine); len(m) > 1 && m[1] != "" && mergedGroupTitle == "" {
-				mergedGroupTitle = m[1]
-			}
-			if m := regTvgLogo.FindStringSubmatch(extinfLine); len(m) > 1 && m[1] != "" && mergedTvgLogo == "" {
-				mergedTvgLogo = m[1]
-			}
-			if m := regTvgRec.FindStringSubmatch(extinfLine); len(m) > 1 && m[1] != "" && mergedTvgRec == "" {
-				mergedTvgRec = m[1]
-			}
-
-			// Longest channel name wins.
-			parts := strings.SplitN(extinfLine, ",", 2)
-			if len(parts) > 1 {
-				name := strings.TrimSpace(parts[1])
-				if len(name) > len(longestName) {
-					longestName = name
-				}
-			}
-		}
-
-		// Build merged EXTINF line from the first entry's structure.
-		firstEntry := group[0]
-		extinfPart := strings.SplitN(firstEntry.EXTINFLine, ",", 2)[0]
-
-		// Remove all existing attribute values.
-		extinfPart = regGroupTitleAttr.ReplaceAllString(extinfPart, "")
-		extinfPart = regTvgIDAttr.ReplaceAllString(extinfPart, "")
-		extinfPart = regTvgLogoAttr.ReplaceAllString(extinfPart, "")
-		extinfPart = regTvgRecAttr.ReplaceAllString(extinfPart, "")
-
-		// Clean up extra whitespace.
-		extinfPart = strings.TrimSpace(extinfPart)
-
-		// Add merged attributes in consistent order.
-		if mergedGroupTitle != "" {
-			extinfPart += fmt.Sprintf(` group-title="%s"`, mergedGroupTitle)
-		}
-		if mergedTvgID != "" {
-			extinfPart += fmt.Sprintf(` tvg-id="%s"`, mergedTvgID)
-		}
-		if mergedTvgLogo != "" {
-			extinfPart += fmt.Sprintf(` tvg-logo="%s"`, mergedTvgLogo)
-		}
-		if mergedTvgRec != "" {
-			extinfPart += fmt.Sprintf(` tvg-rec="%s"`, mergedTvgRec)
-		}
-
-		mergedLine := extinfPart + "," + longestName
-
-		dedupedEntries = append(dedupedEntries, ChannelEntry{
-			EXTINFLine: mergedLine,
-			ExtraLines: firstEntry.ExtraLines,
-		})
-		totalRemoved += len(group) - 1
-	}
-
-	// Append entries without URLs (kept as-is).
-	dedupedEntries = append(dedupedEntries, noURLEntries...)
-
-	if totalRemoved > 0 {
-		logger.Info("Removed %d duplicate URLs from playlist", totalRemoved)
-	}
-
-	var finalLines []string
-	finalLines = append(finalLines, headers...)
-	for _, entry := range dedupedEntries {
-		finalLines = append(finalLines, entry.EXTINFLine)
-		finalLines = append(finalLines, entry.ExtraLines...)
-	}
-	return strings.Join(finalLines, "\n")
-}
-
-// SortPlaylistAlphabetically sorts playlist entries alphabetically by channel name (case-insensitive).
-func SortPlaylistAlphabetically(content string) string {
-	lines := strings.Split(content, "\n")
-	headers, entries := ParseChannelEntries(lines)
-
-	sort.SliceStable(entries, func(i, j int) bool {
-		nameI := channelNameFromEntry(entries[i])
-		nameJ := channelNameFromEntry(entries[j])
-		return strings.ToLower(nameI) < strings.ToLower(nameJ)
-	})
-
-	var finalLines []string
-	finalLines = append(finalLines, headers...)
-	for _, entry := range entries {
-		finalLines = append(finalLines, entry.EXTINFLine)
-		finalLines = append(finalLines, entry.ExtraLines...)
-	}
-	return strings.Join(finalLines, "\n")
-}
-
-// channelNameFromEntry extracts the channel name (part after comma) from an EXTINF line.
-func channelNameFromEntry(entry ChannelEntry) string {
-	parts := strings.SplitN(entry.EXTINFLine, ",", 2)
-	if len(parts) > 1 {
-		return strings.TrimSpace(parts[1])
-	}
-	return ""
-}
-
-func AddTvgIDsToPlaylist(content string, epgNameToIDMap map[string]string) string {
-	lines := strings.Split(content, "\n")
-	addedCount := 0
-
-	for i, line := range lines {
-		if strings.HasPrefix(strings.TrimSpace(line), "#EXTINF:") {
-			if regTvgID.MatchString(line) {
-				continue
-			}
-
-			parts := strings.SplitN(line, ",", 2)
-			if len(parts) > 1 {
-				channelName := strings.TrimSpace(parts[1])
-				normalizedName := strings.ToLower(channelName)
-
-				if tvgID, ok := epgNameToIDMap[normalizedName]; ok {
-					extinfPart := parts[0]
-					lines[i] = fmt.Sprintf(`%s tvg-id="%s",%s`, extinfPart, tvgID, parts[1])
-					addedCount++
-				}
-			}
-		}
-	}
-
-	if addedCount > 0 {
-		logger.Info("Added tvg-id to %d channels", addedCount)
-	}
-	return strings.Join(lines, "\n")
-}
-
-// emojiPoolA are visually distinct shape/color/symbol emojis used as the first component
-// of the emoji pair identifier. The pair provides ~1500+ unique combinations.
-var emojiPoolA = []string{
-	"🔴", "🟠", "🟡", "🟢", "🔵", "🟣", "⚫", "⚪",
-	"🔶", "🔷", "🔸", "🔹", "🔺", "🔻", "⬛", "⬜",
-	"🔘", "⭕", "💠", "💮", "❓", "💢", "💥", "💫",
-	"🌟", "⭐", "✨", "🔥", "💧", "🌊", "☀️", "🌙",
-	"☁️", "⚡", "🌀", "🌈", "💨", "❄️", "🌪", "🌫",
-}
-
-// emojiPoolB are visually distinct object/animal/nature emojis used as the second component.
-var emojiPoolB = []string{
-	"🐶", "🐱", "🐼", "🐯", "🦁", "🦊", "🐻", "🐨",
-	"🐰", "🦄", "🐸", "🐵", "🦋", "🐝", "🐞", "🐌",
-	"🌻", "🌺", "🌹", "🌸", "🌴", "🍀", "🌿", "🍁",
-	"🎯", "🏆", "🎮", "🎸", "🎺", "🎻", "🥁", "📺",
-	"🎬", "🎵", "🎶", "🚀", "🛸", "🎪", "🎭", "🎨",
-}
-
-// urlToEmojiPair generates a deterministic emoji pair (from two pools) based on the URL hash.
-// Same URL always produces the same emoji pair. Uses FNV-1a 64-bit hash for speed and distribution.
-func urlToEmojiPair(url string) string {
-	h := fnv.New64a()
-	h.Write([]byte(url))
-	sum := h.Sum64()
-	a := emojiPoolA[sum%uint64(len(emojiPoolA))]
-	b := emojiPoolB[(sum>>32)%uint64(len(emojiPoolB))]
-	return a + b
-}
-
-// AddEmojiByURL adds a unique emoji pair (e.g. 🔴🐱) to every channel name,
-// deterministically derived from the channel's stream URL via FNV-1a hash.
-// This replaces the previous sequential superscript numbering.
-func AddEmojiByURL(content string) string {
-	lines := strings.Split(content, "\n")
-	headers, entries := ParseChannelEntries(lines)
-
-	for i, entry := range entries {
-		// Extract URL from ExtraLines.
-		url := ""
-		for _, extraLine := range entry.ExtraLines {
-			trimmed := strings.TrimSpace(extraLine)
-			if strings.HasPrefix(trimmed, "http") {
-				url = trimmed
-				break
-			}
-		}
-
-		parts := strings.SplitN(entry.EXTINFLine, ",", 2)
-		if len(parts) > 1 {
-			chName := strings.TrimSpace(parts[1])
-			emoji := urlToEmojiPair(url)
-			newName := fmt.Sprintf("%s %s", chName, emoji)
-			entries[i].EXTINFLine = parts[0] + "," + newName
-		}
-	}
-
-	var finalLines []string
-	finalLines = append(finalLines, headers...)
-	for _, entry := range entries {
-		finalLines = append(finalLines, entry.EXTINFLine)
-		finalLines = append(finalLines, entry.ExtraLines...)
-	}
-	return strings.Join(finalLines, "\n")
-}
-

--- a/internal/s3/s3_test.go
+++ b/internal/s3/s3_test.go
@@ -1,13 +1,15 @@
 package s3
 
 import (
+	"context"
 	"os"
 	"strings"
 	"testing"
 )
 
 func TestUploadToS3InvalidEndpoint(t *testing.T) {
-	err := UploadToS3("content", "bucket", "key", "", "us-east-1", "")
+	ctx := context.Background()
+	err := UploadToS3(ctx, "content", "bucket", "key", "", "us-east-1", "")
 	if err == nil {
 		t.Error("expected error for empty endpoint")
 	}
@@ -17,21 +19,22 @@ func TestUploadToS3InvalidEndpoint(t *testing.T) {
 }
 
 func TestUploadFileToS3InvalidEndpoint(t *testing.T) {
-	err := UploadFileToS3("file.txt", "bucket", "key", "", "bad-url", "us-east-1", "")
+	ctx := context.Background()
+	err := UploadFileToS3(ctx, "file.txt", "bucket", "key", "", "bad-url", "us-east-1", "")
 	if err == nil {
 		t.Error("expected error for invalid endpoint")
 	}
 }
 
 func TestUploadArchiveToS3InvalidEndpoint(t *testing.T) {
-	_, err := UploadArchiveToS3("content", "bucket", "key", "", "us-east-1")
+	ctx := context.Background()
+	_, err := UploadArchiveToS3(ctx, "content", "bucket", "key", "", "us-east-1")
 	if err == nil {
 		t.Error("expected error for empty endpoint")
 	}
 }
 
 func TestNewS3ClientNoCreds(t *testing.T) {
-	// Save original env vars
 	origKey := os.Getenv("AWS_ACCESS_KEY_ID")
 	origSecret := os.Getenv("AWS_SECRET_ACCESS_KEY")
 	defer func() {
@@ -42,11 +45,19 @@ func TestNewS3ClientNoCreds(t *testing.T) {
 	os.Setenv("AWS_ACCESS_KEY_ID", "test-key")
 	os.Setenv("AWS_SECRET_ACCESS_KEY", "test-secret")
 
-	client, err := newS3Client("https://storage.example.com", "ru-central1")
+	client, err := newS3Client(context.Background(), "https://storage.example.com", "ru-central1")
 	if err != nil {
 		t.Fatalf("newS3Client failed: %v", err)
 	}
 	if client == nil {
 		t.Error("expected non-nil client")
+	}
+}
+
+func TestUploadBothInvalidEndpoint(t *testing.T) {
+	ctx := context.Background()
+	err := UploadBoth(ctx, "content", "bucket", "key", "", "us-east-1")
+	if err == nil {
+		t.Error("expected error for empty endpoint")
 	}
 }

--- a/internal/s3/s3_test.go
+++ b/internal/s3/s3_test.go
@@ -7,9 +7,9 @@ import (
 	"testing"
 )
 
-func TestUploadToS3InvalidEndpoint(t *testing.T) {
+func TestNewClientInvalidEndpoint(t *testing.T) {
 	ctx := context.Background()
-	err := UploadToS3(ctx, "content", "bucket", "key", "", "us-east-1", "")
+	_, err := NewClient(ctx, "", "us-east-1")
 	if err == nil {
 		t.Error("expected error for empty endpoint")
 	}
@@ -18,23 +18,7 @@ func TestUploadToS3InvalidEndpoint(t *testing.T) {
 	}
 }
 
-func TestUploadFileToS3InvalidEndpoint(t *testing.T) {
-	ctx := context.Background()
-	err := UploadFileToS3(ctx, "file.txt", "bucket", "key", "", "bad-url", "us-east-1", "")
-	if err == nil {
-		t.Error("expected error for invalid endpoint")
-	}
-}
-
-func TestUploadArchiveToS3InvalidEndpoint(t *testing.T) {
-	ctx := context.Background()
-	_, err := UploadArchiveToS3(ctx, "content", "bucket", "key", "", "us-east-1")
-	if err == nil {
-		t.Error("expected error for empty endpoint")
-	}
-}
-
-func TestNewS3ClientNoCreds(t *testing.T) {
+func TestNewClient(t *testing.T) {
 	origKey := os.Getenv("AWS_ACCESS_KEY_ID")
 	origSecret := os.Getenv("AWS_SECRET_ACCESS_KEY")
 	defer func() {
@@ -45,19 +29,37 @@ func TestNewS3ClientNoCreds(t *testing.T) {
 	os.Setenv("AWS_ACCESS_KEY_ID", "test-key")
 	os.Setenv("AWS_SECRET_ACCESS_KEY", "test-secret")
 
-	client, err := newS3Client(context.Background(), "https://storage.example.com", "ru-central1")
+	ctx := context.Background()
+	client, err := NewClient(ctx, "https://storage.example.com", "ru-central1")
 	if err != nil {
-		t.Fatalf("newS3Client failed: %v", err)
+		t.Fatalf("NewClient failed: %v", err)
 	}
 	if client == nil {
 		t.Error("expected non-nil client")
 	}
 }
 
-func TestUploadBothInvalidEndpoint(t *testing.T) {
+func TestUploadToS3InvalidParams(t *testing.T) {
 	ctx := context.Background()
-	err := UploadBoth(ctx, "content", "bucket", "key", "", "us-east-1")
+	// Passing nil client should handle gracefully.
+	err := UploadToS3(ctx, nil, "content", "bucket", "key", "text/plain")
 	if err == nil {
-		t.Error("expected error for empty endpoint")
+		t.Error("expected error for nil client")
+	}
+}
+
+func TestUploadArchiveToS3InvalidParams(t *testing.T) {
+	ctx := context.Background()
+	_, err := UploadArchiveToS3(ctx, nil, "content", "bucket", "key")
+	if err == nil {
+		t.Error("expected error for nil client")
+	}
+}
+
+func TestUploadBothInvalidParams(t *testing.T) {
+	ctx := context.Background()
+	err := UploadBoth(ctx, nil, "content", "bucket", "key", "")
+	if err == nil {
+		t.Error("expected error for nil client")
 	}
 }

--- a/internal/s3/upload.go
+++ b/internal/s3/upload.go
@@ -63,31 +63,27 @@ func validateEndpoint(s3Endpoint string) error {
 	return nil
 }
 
-func getContentType(contentType string) string {
+func getContentType(contentType string) *string {
 	if contentType == "" {
-		return "application/x-mpegurl"
+		ct := "application/x-mpegurl"
+		return &ct
 	}
-	return contentType
+	return &contentType
 }
 
 // UploadToS3 uploads content as an S3 object with context support.
-func UploadToS3(ctx context.Context, content, bucket, key, s3Endpoint, region, contentType string) error {
-	if err := validateEndpoint(s3Endpoint); err != nil {
-		return err
+func UploadToS3(ctx context.Context, client *s3.Client, content, bucket, key, contentType string) error {
+	if client == nil {
+		return fmt.Errorf("S3 client is nil")
 	}
 	logger.Info("Uploading to S3-compatible storage: s3://%s/%s", bucket, key)
 
-	client, err := newS3Client(ctx, s3Endpoint, region)
-	if err != nil {
-		return err
-	}
-
 	ct := getContentType(contentType)
-	_, err = client.PutObject(ctx, &s3.PutObjectInput{
+	_, err := client.PutObject(ctx, &s3.PutObjectInput{
 		Bucket:      &bucket,
 		Key:         &key,
 		Body:        strings.NewReader(content),
-		ContentType: &ct,
+		ContentType: ct,
 		Metadata:    buildS3Metadata(),
 	})
 	if err != nil {
@@ -100,11 +96,10 @@ func UploadToS3(ctx context.Context, content, bucket, key, s3Endpoint, region, c
 }
 
 // UploadFileToS3 uploads a local file to S3 with context support.
-func UploadFileToS3(ctx context.Context, filePath, bucket, key, outputDir, s3Endpoint, region, contentType string) error {
-	if err := validateEndpoint(s3Endpoint); err != nil {
-		return err
+func UploadFileToS3(ctx context.Context, client *s3.Client, filePath, bucket, key, outputDir, contentType string) error {
+	if client == nil {
+		return fmt.Errorf("S3 client is nil")
 	}
-
 	fullPath := filePath
 	if outputDir != "" {
 		altPath := path.Join(outputDir, path.Base(filePath))
@@ -120,17 +115,12 @@ func UploadFileToS3(ctx context.Context, filePath, bucket, key, outputDir, s3End
 		return fmt.Errorf("failed to read file %s: %w", fullPath, err)
 	}
 
-	client, err := newS3Client(ctx, s3Endpoint, region)
-	if err != nil {
-		return err
-	}
-
 	ct := getContentType(contentType)
 	_, err = client.PutObject(ctx, &s3.PutObjectInput{
 		Bucket:      &bucket,
 		Key:         &key,
 		Body:        bytes.NewReader(data),
-		ContentType: &ct,
+		ContentType: ct,
 		Metadata:    buildS3Metadata(map[string]string{"source-file": fullPath}),
 	})
 	if err != nil {
@@ -143,11 +133,10 @@ func UploadFileToS3(ctx context.Context, filePath, bucket, key, outputDir, s3End
 }
 
 // UploadArchiveToS3 gzip-compresses content and uploads it to S3 under archive/YYYY-MM-DD/.
-func UploadArchiveToS3(ctx context.Context, content, bucket, baseKey, s3Endpoint, region string) (string, error) {
-	if err := validateEndpoint(s3Endpoint); err != nil {
-		return "", err
+func UploadArchiveToS3(ctx context.Context, client *s3.Client, content, bucket, baseKey string) (string, error) {
+	if client == nil {
+		return "", fmt.Errorf("S3 client is nil")
 	}
-
 	now := time.Now().UTC()
 	dateStr := now.Format("2006-01-02")
 	timeStr := now.Format("15-04-05")
@@ -165,16 +154,12 @@ func UploadArchiveToS3(ctx context.Context, content, bucket, baseKey, s3Endpoint
 	}
 	gw.Close()
 
-	client, err := newS3Client(ctx, s3Endpoint, region)
-	if err != nil {
-		return "", err
-	}
-
+	clientForUpload := client
 	originalSizeKB := float64(len(content)) / 1024
 	compressedSizeKB := float64(buf.Len()) / 1024
 	contentType := "application/gzip"
 
-	_, err = client.PutObject(ctx, &s3.PutObjectInput{
+	_, err := clientForUpload.PutObject(ctx, &s3.PutObjectInput{
 		Bucket:      &bucket,
 		Key:         &archiveKey,
 		Body:        bytes.NewReader(buf.Bytes()),
@@ -193,14 +178,20 @@ func UploadArchiveToS3(ctx context.Context, content, bucket, baseKey, s3Endpoint
 	return archiveKey, nil
 }
 
-// UploadBoth uploads content as both a direct S3 object and a gzip archive.
-func UploadBoth(ctx context.Context, content, bucket, key, s3Endpoint, region string) error {
-	// Archive upload.
-	if _, err := UploadArchiveToS3(ctx, content, bucket, key, s3Endpoint, region); err != nil {
+// NewClient creates a reusable S3 client.
+func NewClient(ctx context.Context, s3Endpoint, region string) (*s3.Client, error) {
+	if err := validateEndpoint(s3Endpoint); err != nil {
+		return nil, err
+	}
+	return newS3Client(ctx, s3Endpoint, region)
+}
+
+// UploadBoth uploads content as both a direct S3 object and a gzip archive using an existing client.
+func UploadBoth(ctx context.Context, client *s3.Client, content, bucket, key, contentType string) error {
+	if _, err := UploadArchiveToS3(ctx, client, content, bucket, key); err != nil {
 		return fmt.Errorf("archive upload failed: %w", err)
 	}
-	// Direct upload.
-	if err := UploadToS3(ctx, content, bucket, key, s3Endpoint, region, ""); err != nil {
+	if err := UploadToS3(ctx, client, content, bucket, key, contentType); err != nil {
 		return fmt.Errorf("direct upload failed: %w", err)
 	}
 	return nil

--- a/internal/s3/upload.go
+++ b/internal/s3/upload.go
@@ -18,15 +18,12 @@ import (
 	"github.com/ozyab/iptv/internal/utils"
 )
 
-// Package-level logger with sanitized output.
 var logger = utils.NewSanitizedLoggerWithPrefix("[s3]")
 
-// metadata is shared across all S3 uploads for consistent tracking.
 var defaultMetadata = map[string]string{
 	"uploaded-by": "iptv-m3u-filter",
 }
 
-// buildS3Metadata creates a metadata map with a timestamp.
 func buildS3Metadata(extra ...map[string]string) map[string]string {
 	m := make(map[string]string, len(defaultMetadata)+1+len(extra))
 	for k, v := range defaultMetadata {
@@ -41,12 +38,11 @@ func buildS3Metadata(extra ...map[string]string) map[string]string {
 	return m
 }
 
-// newS3Client creates an S3 client configured for the given endpoint and region.
-func newS3Client(s3Endpoint, region string) (*s3.Client, error) {
+func newS3Client(ctx context.Context, s3Endpoint, region string) (*s3.Client, error) {
 	accessKey := os.Getenv("AWS_ACCESS_KEY_ID")
 	secretKey := os.Getenv("AWS_SECRET_ACCESS_KEY")
 
-	awsCfg, err := config.LoadDefaultConfig(context.TODO(),
+	awsCfg, err := config.LoadDefaultConfig(ctx,
 		config.WithRegion(region),
 		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(accessKey, secretKey, "")),
 	)
@@ -60,7 +56,6 @@ func newS3Client(s3Endpoint, region string) (*s3.Client, error) {
 	}), nil
 }
 
-// validateEndpoint checks that the S3 endpoint URL is a valid HTTP/HTTPS URL.
 func validateEndpoint(s3Endpoint string) error {
 	if s3Endpoint == "" || (!strings.HasPrefix(s3Endpoint, "http://") && !strings.HasPrefix(s3Endpoint, "https://")) {
 		return fmt.Errorf("invalid S3 endpoint URL: %s. Must be a valid HTTP/HTTPS URL", s3Endpoint)
@@ -68,7 +63,6 @@ func validateEndpoint(s3Endpoint string) error {
 	return nil
 }
 
-// getContentType returns the provided contentType or defaults to "application/x-mpegurl".
 func getContentType(contentType string) string {
 	if contentType == "" {
 		return "application/x-mpegurl"
@@ -76,20 +70,20 @@ func getContentType(contentType string) string {
 	return contentType
 }
 
-// UploadToS3 uploads a string as an S3 object.
-func UploadToS3(content, bucket, key, s3Endpoint, region, contentType string) error {
+// UploadToS3 uploads content as an S3 object with context support.
+func UploadToS3(ctx context.Context, content, bucket, key, s3Endpoint, region, contentType string) error {
 	if err := validateEndpoint(s3Endpoint); err != nil {
 		return err
 	}
 	logger.Info("Uploading to S3-compatible storage: s3://%s/%s", bucket, key)
 
-	client, err := newS3Client(s3Endpoint, region)
+	client, err := newS3Client(ctx, s3Endpoint, region)
 	if err != nil {
 		return err
 	}
 
 	ct := getContentType(contentType)
-	_, err = client.PutObject(context.TODO(), &s3.PutObjectInput{
+	_, err = client.PutObject(ctx, &s3.PutObjectInput{
 		Bucket:      &bucket,
 		Key:         &key,
 		Body:        strings.NewReader(content),
@@ -105,13 +99,12 @@ func UploadToS3(content, bucket, key, s3Endpoint, region, contentType string) er
 	return nil
 }
 
-// UploadFileToS3 uploads a local file to S3.
-func UploadFileToS3(filePath, bucket, key, outputDir, s3Endpoint, region, contentType string) error {
+// UploadFileToS3 uploads a local file to S3 with context support.
+func UploadFileToS3(ctx context.Context, filePath, bucket, key, outputDir, s3Endpoint, region, contentType string) error {
 	if err := validateEndpoint(s3Endpoint); err != nil {
 		return err
 	}
 
-	// If file not found at filePath, try outputDir + filename.
 	fullPath := filePath
 	if outputDir != "" {
 		altPath := path.Join(outputDir, path.Base(filePath))
@@ -127,13 +120,13 @@ func UploadFileToS3(filePath, bucket, key, outputDir, s3Endpoint, region, conten
 		return fmt.Errorf("failed to read file %s: %w", fullPath, err)
 	}
 
-	client, err := newS3Client(s3Endpoint, region)
+	client, err := newS3Client(ctx, s3Endpoint, region)
 	if err != nil {
 		return err
 	}
 
 	ct := getContentType(contentType)
-	_, err = client.PutObject(context.TODO(), &s3.PutObjectInput{
+	_, err = client.PutObject(ctx, &s3.PutObjectInput{
 		Bucket:      &bucket,
 		Key:         &key,
 		Body:        bytes.NewReader(data),
@@ -150,7 +143,7 @@ func UploadFileToS3(filePath, bucket, key, outputDir, s3Endpoint, region, conten
 }
 
 // UploadArchiveToS3 gzip-compresses content and uploads it to S3 under archive/YYYY-MM-DD/.
-func UploadArchiveToS3(content, bucket, baseKey, s3Endpoint, region string) (string, error) {
+func UploadArchiveToS3(ctx context.Context, content, bucket, baseKey, s3Endpoint, region string) (string, error) {
 	if err := validateEndpoint(s3Endpoint); err != nil {
 		return "", err
 	}
@@ -165,7 +158,6 @@ func UploadArchiveToS3(content, bucket, baseKey, s3Endpoint, region string) (str
 
 	logger.Info("Uploading archive to S3: s3://%s/%s", bucket, archiveKey)
 
-	// Gzip compress the content.
 	var buf bytes.Buffer
 	gw := gzip.NewWriter(&buf)
 	if _, err := gw.Write([]byte(content)); err != nil {
@@ -173,7 +165,7 @@ func UploadArchiveToS3(content, bucket, baseKey, s3Endpoint, region string) (str
 	}
 	gw.Close()
 
-	client, err := newS3Client(s3Endpoint, region)
+	client, err := newS3Client(ctx, s3Endpoint, region)
 	if err != nil {
 		return "", err
 	}
@@ -182,7 +174,7 @@ func UploadArchiveToS3(content, bucket, baseKey, s3Endpoint, region string) (str
 	compressedSizeKB := float64(buf.Len()) / 1024
 	contentType := "application/gzip"
 
-	_, err = client.PutObject(context.TODO(), &s3.PutObjectInput{
+	_, err = client.PutObject(ctx, &s3.PutObjectInput{
 		Bucket:      &bucket,
 		Key:         &archiveKey,
 		Body:        bytes.NewReader(buf.Bytes()),
@@ -199,4 +191,17 @@ func UploadArchiveToS3(content, bucket, baseKey, s3Endpoint, region string) (str
 
 	logger.Info("Archive upload completed: %s (%.2f KB, original: %.2f KB)", archiveKey, compressedSizeKB, originalSizeKB)
 	return archiveKey, nil
+}
+
+// UploadBoth uploads content as both a direct S3 object and a gzip archive.
+func UploadBoth(ctx context.Context, content, bucket, key, s3Endpoint, region string) error {
+	// Archive upload.
+	if _, err := UploadArchiveToS3(ctx, content, bucket, key, s3Endpoint, region); err != nil {
+		return fmt.Errorf("archive upload failed: %w", err)
+	}
+	// Direct upload.
+	if err := UploadToS3(ctx, content, bucket, key, s3Endpoint, region, ""); err != nil {
+		return fmt.Errorf("direct upload failed: %w", err)
+	}
+	return nil
 }

--- a/internal/utils/helper.go
+++ b/internal/utils/helper.go
@@ -1,0 +1,22 @@
+package utils
+
+import (
+	"strings"
+)
+
+// ToLowerSlice converts a slice of strings to lowercase, returning a new slice.
+func ToLowerSlice(src []string) []string {
+	if src == nil {
+		return nil
+	}
+	dst := make([]string, len(src))
+	for i, s := range src {
+		dst[i] = strings.ToLower(s)
+	}
+	return dst
+}
+
+// NormalizeLineEndings converts \r\n to \n for consistent handling.
+func NormalizeLineEndings(content string) string {
+	return strings.ReplaceAll(content, "\r\n", "\n")
+}

--- a/internal/utils/http.go
+++ b/internal/utils/http.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"io"
@@ -8,18 +9,32 @@ import (
 	"time"
 )
 
-// HTTPClient is a shared HTTP client with disabled SSL verification (needed for local dev).
-var HTTPClient = &http.Client{
-	Transport: &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-	},
-	Timeout: 30 * time.Minute,
+// NewHTTPClient creates an HTTP client with optional SSL verification bypass.
+func NewHTTPClient(skipSSLVerify bool) *http.Client {
+	return &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: skipSSLVerify},
+		},
+		Timeout: 30 * time.Minute,
+	}
 }
 
 // DownloadFile performs an HTTP GET and returns raw bytes, enforcing a maxSize limit.
-// Shared by both M3U and EPG downloaders to avoid code duplication.
+// Uses the default HTTP client with SSL verification enabled.
 func DownloadFile(url string, maxSize int) ([]byte, error) {
-	resp, err := HTTPClient.Get(url)
+	return DownloadFileWithContext(context.Background(), url, maxSize, false)
+}
+
+// DownloadFileWithContext performs an HTTP GET with context support, enforcing a maxSize limit.
+func DownloadFileWithContext(ctx context.Context, url string, maxSize int, skipSSLVerify bool) ([]byte, error) {
+	client := NewHTTPClient(skipSSLVerify)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("HTTP GET failed: %w", err)
 	}

--- a/internal/utils/logger.go
+++ b/internal/utils/logger.go
@@ -38,8 +38,12 @@ func (s *SanitizedWriter) Error(format string, args ...interface{}) {
 }
 
 var urlPattern = regexp.MustCompile(`https?://[^\s'"<>]+`)
-var awsKeyPattern = regexp.MustCompile(`(YCAJEu[A-Za-z0-9_\-]+)`)
-var awsSecretPattern = regexp.MustCompile(`(YCON[A-Za-z0-9_\-]+)`)
+
+// Supported credential patterns:
+// - Yandex Cloud: YCAJEu... (key), YCON... (secret)
+// - AWS: AKIA... / ASIA... (access key)
+var awsKeyPattern = regexp.MustCompile(`(YCAJEu[A-Za-z0-9_\-]+|AKIA[A-Za-z0-9_\-]{16}|ASIA[A-Za-z0-9_\-]{16})`)
+var awsSecretPattern = regexp.MustCompile(`(YCON[A-Za-z0-9_\-]+|\*{10,}[A-Za-z0-9+/=]{10,})`)
 
 func sanitizeLogMessage(format string, args ...interface{}) string {
 	msg := format


### PR DESCRIPTION
Closes #78

## Изменения

### Config
- Кэширование env-var в структуре Config (освобождает от os.Getenv на каждый вызов)
- Дедиз CategoriesToRemove (46→26): удалены 20 дублей (original + normalized)
- Добавлен SKIP_SSL_VERIFY env var (безопасность по умолчанию)

### HTTP / Utils
- DownloadFileWithContext — поддержка context.Context
- NewHTTPClient(skipSSLVerify) — конфигурируемая SSL-верификация
- ToLowerSlice, NormalizeLineEndings — вспомогательные утилиты

### S3
- Все функции принимают context.Context
- UploadBoth — объединяет archive + direct upload (убрано дублирование в main.go)

### EPG
- Streaming xml.Decoder вместо полного xml.Unmarshal (экономия памяти при 463MB XML)

### M3U
- Pipeline-рефакторинг FilterContent: выделены processHeader, filterEntry
- Использование ToLowerSlice и NormalizeLineEndings

### Main
- Graceful shutdown: SIGINT/SIGTERM через context cancellation
- processEPG возвращает (string, error) вместо *string
- uploadBoth для deduplicated S3 upload

## Testing
- 35 тестов PASS
- go vet — чистый
- Dry-run: 10,466 → 3,030 каналов, EPG 38,467 программ, без ошибок