### PR TITLE
fix: update CI - bump upload-artifact to v5 + remove artifact upload (personal data)

### DIFF
--- a/.github/workflows/filter-m3u.yml
+++ b/.github/workflows/filter-m3u.yml
@@ -80,10 +80,3 @@ jobs:
     - name: Run M3U filter script
       run: ./iptv-filter
 
-    - name: Upload output artifacts
-      if: always()
-      uses: actions/upload-artifact@v5
-      with:
-        name: output
-        path: output/
-        retention-days: 7

--- a/.github/workflows/filter-m3u.yml
+++ b/.github/workflows/filter-m3u.yml
@@ -82,7 +82,7 @@ jobs:
 
     - name: Upload output artifacts
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         name: output
         path: output/


### PR DESCRIPTION
## Changes

1. **actions/upload-artifact@v4 → @v5** — fixes Node.js 20 deprecation warning (runner is on Node.js 24)
2. **Removed artifact upload step entirely** — playlists contain personal channel data, should not be stored as CI artifacts

## Testing
- CI workflow only change, no Go code modified
- Build and tests unaffected