### PR TITLE
feat: exclude category Гранд from M3U filter

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -197,6 +197,9 @@ var CategoriesToRemove = []string{
 	"𝕂иℍ𝕠",
 	// Региональные категории
 	"РОССИЯ+",
+
+	// Другие
+	"Гранд",
 }
 
 // CategoriesToRemoveSubstring lists substrings to match against group-title (case-insensitive).

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -95,6 +95,7 @@ func TestCategoriesToRemove(t *testing.T) {
 		"𝐊𝐢𝐧𝐨",
 		"𝕂иℍ𝕠",
 		"РОССИЯ+",
+		"Гранд",
 	}
 	if len(CategoriesToRemove) != len(expected) {
 		t.Errorf("expected %d categories, got %d", len(expected), len(CategoriesToRemove))


### PR DESCRIPTION
Closes #81

Add "Гранд" to CategoriesToRemove exact-match deny list.
All channels with group-title matching "Гранд" will be filtered out.