### PR TITLE
feat: derive emoji pair from URL hostname and path, expand pools to 100+

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Project
 
-IPTV M3U playlist filter: downloads M3U from HTTP URLs, filters by category (deny-list), normalizes names (remove `orig`, exclude regional `+N` variants), assigns unique emoji pairs to channels deterministically derived from stream URL via FNV-1a hash, optionally processes EPG, uploads to S3-compatible storage (Yandex Cloud).
+IPTV M3U playlist filter: downloads M3U from HTTP URLs, filters by category (deny-list), normalizes names (remove `orig`, exclude regional `+N` variants), assigns unique emoji pairs to channels deterministically derived from stream URL (first emoji from hostname, second from path) via FNV-1a hash, optionally processes EPG, uploads to S3-compatible storage (Yandex Cloud).
 
 ## Language & runtime
 
@@ -116,7 +116,7 @@ Key exported functions:
 - `FilterContent()` — main pipeline: normalization, category filtering (exact + substring), name exclusion, regional suffix removal, numeric suffix removal, `orig` removal, dedup, sort, emoji
 - `RemoveDuplicateURLs()` — deduplicates by URL, merges attributes (tvg-id, group-title, tvg-logo, tvg-rec), keeps longest name
 - `SortPlaylistAlphabetically()` — A-Z by channel name (case-insensitive, stable sort)
-- `AddEmojiByURL()` — appends FNV-1a based emoji pair (🔴🐱) to each channel name; 40×40 pools = ~1600 combinations
+- `AddEmojiByURL()` — appends FNV-1a based emoji pair (🔴🐱) to each channel name; first emoji derived from URL hostname, second from URL path; 100+×100+ pools = ~10,000+ combinations
 - `AddTvgIDsToPlaylist()` — adds `tvg-id` from EPG name-to-id map
 - `RemoveOrigSuffix()` — strips trailing " orig"
 - `ParseCategoriesFile()` / `ApplyChannelMetadata()` — categories.txt override
@@ -177,7 +177,7 @@ Filtering steps per entry:
 - **Group-title normalization**: leading numbers (`^\\d+.\\s*`) stripped, trailing emojis stripped
 - **Channel exclusions**: by name substring (6 patterns), regional suffix (`+N`), numeric suffix (`2+` digits at end)
 - **Name processing**: `orig` suffix removed
-- **Emoji identifiers**: FNV-1a 64-bit hash of stream URL → pair from 2×40 emoji pools, appended to channel name
+- **Emoji identifiers**: FNV-1a 64-bit hash → first emoji from URL hostname (DNS name, port ignored), second from URL path (query ignored); pools of 100+ emojis each (~10,000+ combinations), appended to channel name
 - **Dedup by URL**: first non-empty attributes merged, longest name wins
 - **Sort**: A-Z case-insensitive stable sort after dedup
 - **Metadata overrides**: `categories.txt` can supply `group-title`/`tvg-id` via `CATEGORIES_FILE_PATH` env var

--- a/internal/m3u/m3u_test.go
+++ b/internal/m3u/m3u_test.go
@@ -313,6 +313,78 @@ func TestUrlToEmojiPairDeterministic(t *testing.T) {
 	}
 }
 
+func TestUrlToEmojiPairUsesHostnameAndPath(t *testing.T) {
+	// Первый эмодзи (по hostname) одинаков для одного DNS-имени, порт не влияет.
+	h1 := emojiFromHostname("http://cdn.example.com:8080/live/ch1.m3u8?token=abc")
+	h2 := emojiFromHostname("http://cdn.example.com/live/ch2.m3u8?token=def")
+	if h1 != h2 {
+		t.Errorf("same hostname should produce same first emoji: %q vs %q", h1, h2)
+	}
+
+	// Разные hostname — почти наверняка разные первые эмодзи.
+	h3 := emojiFromHostname("http://cdn.other.net/live/ch1.m3u8")
+	if h1 == h3 {
+		t.Logf("note: different hostnames produced same emoji %q (possible but unlikely)", h1)
+	}
+
+	// Второй эмодзи (по path) различается для разных путей на одном хосте.
+	p1 := emojiFromPath("http://cdn.example.com/live/ch1.m3u8")
+	p2 := emojiFromPath("http://cdn.example.com/live/ch2.m3u8")
+	if p1 == p2 {
+		t.Logf("note: different paths produced same emoji %q (possible but unlikely)", p1)
+	}
+
+	// Одинаковый путь на разных хостах → одинаковый второй эмодзи.
+	p3 := emojiFromPath("http://cdn.other.net/live/ch1.m3u8")
+	if p1 != p3 {
+		t.Errorf("same path should produce same second emoji: %q vs %q", p1, p3)
+	}
+
+	// Query-строка не должна влиять на второй эмодзи.
+	p4 := emojiFromPath("http://cdn.example.com/live/ch1.m3u8?token=xyz")
+	if p1 != p4 {
+		t.Errorf("query string must not affect path emoji: %q vs %q", p1, p4)
+	}
+}
+
+func TestUrlComponentFallback(t *testing.T) {
+	// Некорректный URL не должен паниковать и должен давать fallback.
+	if got := urlComponent("not a url ://", true); got == "" {
+		t.Error("expected non-empty fallback for malformed URL")
+	}
+	// Относительный URL (без хоста) → fallback на всю строку.
+	if got := urlComponent("relative/path.m3u8", false); got != "relative/path.m3u8" {
+		t.Errorf("expected raw fallback for relative URL, got %q", got)
+	}
+	// Hostname: порт отбрасывается, DNS-имя приводится к нижнему регистру.
+	if got := urlComponent("http://CDN.Example.COM:8080/x", true); got != "cdn.example.com" {
+		t.Errorf("expected lowercased hostname without port, got %q", got)
+	}
+	// Пустой path → "/".
+	if got := urlComponent("http://cdn.example.com", false); got != "/" {
+		t.Errorf("expected \"/\" for empty path, got %q", got)
+	}
+}
+
+func TestEmojiPoolsExpanded(t *testing.T) {
+	if len(emojiPoolA) < 100 {
+		t.Errorf("emojiPoolA must have at least 100 emojis, got %d", len(emojiPoolA))
+	}
+	if len(emojiPoolB) < 100 {
+		t.Errorf("emojiPoolB must have at least 100 emojis, got %d", len(emojiPoolB))
+	}
+	// Внутри пула не должно быть дубликатов (они бы тратили комбинации).
+	for name, pool := range map[string][]string{"A": emojiPoolA, "B": emojiPoolB} {
+		seen := make(map[string]bool)
+		for _, e := range pool {
+			if seen[e] {
+				t.Errorf("duplicate emoji in pool %s: %q", name, e)
+			}
+			seen[e] = true
+		}
+	}
+}
+
 func TestFilterContentWithCategories(t *testing.T) {
 	content := `#EXTM3U
 #EXTINF:-1 group-title="Взрослые",Adult Channel

--- a/internal/m3u/processor.go
+++ b/internal/m3u/processor.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"hash/fnv"
+	"net/url"
 	"os"
 	"regexp"
 	"sort"
@@ -84,29 +85,106 @@ func channelNameFromEntry(entry ChannelEntry) string {
 
 // ─── Emoji helpers ────────────────────────────────────────────────────────────────
 
+// emojiPoolA: 100+ символов (геометрия, погода, космос, сердца, знаки).
+// Первый эмодзи пары канала формируется из hostname (DNS-имени) URL потока.
 var emojiPoolA = []string{
+	// Геометрия и цвета.
 	"🔴", "🟠", "🟡", "🟢", "🔵", "🟣", "⚫", "⚪",
 	"🔶", "🔷", "🔸", "🔹", "🔺", "🔻", "⬛", "⬜",
 	"🔘", "⭕", "💠", "💮", "❓", "💢", "💥", "💫",
+	"🟥", "🟧", "🟨", "🟩", "🟦", "🟪", "🟫",
+	"◼️", "◻️", "◽", "◾", "🔲", "🔳",
+	// Погода, небо и космос.
 	"🌟", "⭐", "✨", "🔥", "💧", "🌊", "☀️", "🌙",
 	"☁️", "⚡", "🌀", "🌈", "💨", "❄️", "🌪", "🌫",
+	"🌤️", "🌥️", "🌦️", "🌧️", "🌨️", "🌩️", "⛈️", "🌬️",
+	"🌍", "🌎", "🌏", "🌕", "🌖", "🌗", "🌘", "🌑",
+	"🌒", "🌓", "🌔", "🌝", "🌚", "🌛", "🌜", "🌞",
+	"🌠", "☄️",
+	// Сердца.
+	"❤️", "🧡", "💛", "💚", "💙", "💜", "🖤", "🤍",
+	"🤎", "💖", "💗", "💓", "💞", "💕", "💘", "💝",
+	"💟", "❣️", "💔",
+	// Знаки и символы.
+	"✅", "❌", "❎", "➕", "➖", "✖️", "💯", "🔟",
+	"🏁", "🚩", "🎌",
 }
 
+// emojiPoolB: 100+ эмодзи (животные, растения, еда, объекты, транспорт).
+// Второй эмодзи пары канала формируется из path-части URL потока.
 var emojiPoolB = []string{
+	// Животные.
 	"🐶", "🐱", "🐼", "🐯", "🦁", "🦊", "🐻", "🐨",
 	"🐰", "🦄", "🐸", "🐵", "🦋", "🐝", "🐞", "🐌",
+	"🐭", "🐹", "🐺", "🐗", "🐴", "🐮", "🐷", "🐽",
+	"🐍", "🦎", "🐢", "🐙", "🦑", "🦐", "🦞", "🦀",
+	"🐡", "🐠", "🐟", "🐬", "🐳", "🐋", "🦈", "🐊",
+	"🐅", "🐆", "🦓", "🦍", "🦧", "🐘", "🦛", "🦏",
+	"🐪", "🐫", "🦒", "🦘", "🐃", "🐂", "🐄", "🐎",
+	"🐖", "🐏", "🐑", "🦙", "🐐", "🦌", "🐕", "🐩",
+	"🦮", "🦚", "🦜", "🦢", "🦩", "🦝", "🦨", "🦡",
+	"🦫", "🦦", "🦥", "🐀", "🐿️", "🦔", "🐉", "🐲",
+	// Растения.
 	"🌻", "🌺", "🌹", "🌸", "🌴", "🍀", "🌿", "🍁",
-	"🎯", "🏆", "🎮", "🎸", "🎺", "🎻", "🥁", "📺",
-	"🎬", "🎵", "🎶", "🚀", "🛸", "🎪", "🎭", "🎨",
+	"🌵", "🌲", "🌳", "🌱", "🍃", "🍂", "🌾", "💐",
+	"🌷", "🌼", "🌽", "🌶️", "🥀",
+	// Еда.
+	"🍎", "🍊", "🍋", "🍇", "🍓", "🍉", "🍒", "🍑",
+	"🥭", "🍍", "🥥", "🍅", "🥑", "🥕", "🥔", "🍞",
+	"🧀", "🥚", "🍳", "🥞", "🥓", "🍗", "🍖", "🌭",
+	"🍔", "🍟", "🍕", "🌮", "🥗", "🍜", "🍣", "🍦",
+	"🍰", "🎂", "🍭", "🍬", "🍫", "🍿", "🍩", "🍪",
+	"🍺", "🍷", "🥛", "🍵", "☕",
+	// Объекты и транспорт.
+	"🏀", "⚽", "🎾", "🏐", "🎱", "🏓", "🎳", "⛳",
+	"🏅", "🎟️", "🎫", "🎰", "🧩", "🎲", "♟️", "🎧",
+	"🎤", "🎹", "🪗", "🪕", "💻", "📱", "⌚", "🗿",
+	"🗼", "🏰", "🏯", "🗽", "🚗", "🚕", "🚙", "🚌",
+	"🏎️", "🚓", "🚑", "🚒", "🚚", "🚜", "🛵", "🚲",
+	"✈️", "🛫", "🛬", "🚁", "🛶", "⛵", "🚤", "🚢",
 }
 
-func urlToEmojiPair(url string) string {
+// urlToEmojiPair returns a two-emoji identifier for a stream URL:
+// the first emoji is derived from the URL hostname, the second from the URL path.
+func urlToEmojiPair(rawURL string) string {
+	return emojiFromHostname(rawURL) + emojiFromPath(rawURL)
+}
+
+// emojiFromHostname derives an emoji from the URL hostname (DNS name, port ignored).
+func emojiFromHostname(rawURL string) string {
+	host := urlComponent(rawURL, true)
+	return emojiPoolA[fnv64(host)%uint64(len(emojiPoolA))]
+}
+
+// emojiFromPath derives an emoji from the URL path part.
+func emojiFromPath(rawURL string) string {
+	path := urlComponent(rawURL, false)
+	return emojiPoolB[fnv64(path)%uint64(len(emojiPoolB))]
+}
+
+// fnv64 computes the FNV-1a 64-bit hash of a string.
+func fnv64(s string) uint64 {
 	h := fnv.New64a()
-	h.Write([]byte(url))
-	sum := h.Sum64()
-	a := emojiPoolA[sum%uint64(len(emojiPoolA))]
-	b := emojiPoolB[(sum>>32)%uint64(len(emojiPoolB))]
-	return a + b
+	h.Write([]byte(s))
+	return h.Sum64()
+}
+
+// urlComponent extracts the hostname (wantHost=true) or path (wantHost=false) part
+// of a URL for emoji derivation. Falls back to the raw URL string when parsing
+// fails or the URL has no hostname (relative/malformed URLs).
+func urlComponent(rawURL string, wantHost bool) string {
+	u, err := url.Parse(rawURL)
+	if err != nil || u.Hostname() == "" {
+		return rawURL
+	}
+	if wantHost {
+		return strings.ToLower(u.Hostname())
+	}
+	path := u.Path
+	if path == "" {
+		path = "/"
+	}
+	return path
 }
 
 // ─── Downloads ────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #83

## What

- First emoji in the channel name pair is now derived from the stream URL **hostname** (DNS name, port ignored, lowercased)
- Second emoji is derived from the URL **path** (query string ignored)
- Emoji pools expanded from 40 to 100+ entries each: **109** (pool A) + **194** (pool B) = ~21k combinations
- Safe deterministic fallback to the raw URL string for malformed/relative URLs (no panics)

## Why

Channels on the same host (e.g. a CDN) now share the same first emoji, which acts as a host-level visual grouping, while the path-derived second emoji distinguishes individual channels.

## Tests

- `go vet ./...` — clean
- `go test ./... -count=1` — all packages pass
- New: `TestUrlToEmojiPairUsesHostnameAndPath`, `TestUrlComponentFallback`, `TestEmojiPoolsExpanded`
