### PR TITLE
feat: reduce default EPG retention to 3 days

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,7 +80,7 @@ iptv/
 | `S3Region()` | `S3_REGION` | `us-east-1` |
 | `EPGSourceURL()` | `EPG_SOURCE_URL` | — |
 | `S3EPGKey()` | `S3_EPG_KEY` | — |
-| `EPGRetentionDays()` | `EPG_RETENTION_DAYS` | `10` |
+| `EPGRetentionDays()` | `EPG_RETENTION_DAYS` | `3` |
 | `OutputDir()` | `OUTPUT_DIR` | `output` |
 | `CategoriesFilePath()` | `CATEGORIES_FILE_PATH` | — |
 | `DryRun()` | `DRY_RUN` | `false` |
@@ -144,7 +144,7 @@ Filtering steps per entry:
   - Second pass eliminated (merged into one pass — channels come before programmes in XMLTV)
   - Filters channels by ID/name matching
   - Applies category exclusions and channel ID exclusions
-  - Applies time-based retention (default 10 days)
+  - Applies time-based retention (default 3 days)
   - Returns filtered XML with `xml.MarshalIndent`
 - `SaveFilteredEPGLocally()` — saves with gzip compression if filename ends with `.gz`
 
@@ -185,7 +185,7 @@ Filtering steps per entry:
 ## EPG processing (internal/epg/)
 
 - Downloads from `EPG_SOURCE_URL` (supports `.gz` and `.zip`)
-- `EPG_RETENTION_DAYS` (default: 10) — discards programmes outside this window
+- `EPG_RETENTION_DAYS` (default: 3) — discards programmes outside this window
 - `EPGExcludedCategories` — categories excluded from EPG (default: `Кино`)
 - `EPGExcludedChannelIDs` — 31 specific channel IDs
 - Filtering uses **single-pass streaming** `xml.Decoder` (no full 463MB `xml.Unmarshal`)

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Set these environment variables:
 | `AWS_SECRET_ACCESS_KEY` | S3 secret key | required |
 | `DRY_RUN` | Skip S3 upload | (unset) |
 | `OUTPUT_DIR` | Local output directory | `output` |
-| `EPG_RETENTION_DAYS` | EPG retention window | `10` |
+| `EPG_RETENTION_DAYS` | EPG retention window | `3` |
 | `CATEGORIES_FILE_PATH` | Path to categories.txt | (optional) |
 
 Load with:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -39,7 +39,7 @@ func New() *Config {
 		epgSourceURL:  os.Getenv("EPG_SOURCE_URL"),
 		s3EPGKey:      os.Getenv("S3_EPG_KEY"),
 		localEPGPath:  envOrDefault("LOCAL_EPG_PATH", "epg.xml.gz"),
-		epgRetention:  envIntOrDefault("EPG_RETENTION_DAYS", 10),
+		epgRetention:  envIntOrDefault("EPG_RETENTION_DAYS", 3),
 		outputDir:     envOrDefault("OUTPUT_DIR", "output"),
 		categoriesFile: os.Getenv("CATEGORIES_FILE_PATH"),
 		dryRun:        isTruthy(os.Getenv("DRY_RUN")),

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -145,8 +145,8 @@ func TestEPGExcludedChannelIDs(t *testing.T) {
 
 func TestEPGRetentionDaysDefault(t *testing.T) {
 	cfg := New()
-	if cfg.EPGRetentionDays() != 10 {
-		t.Errorf("expected EPGRetentionDays to be 10, got %d", cfg.EPGRetentionDays())
+	if cfg.EPGRetentionDays() != 3 {
+		t.Errorf("expected EPGRetentionDays to be 3, got %d", cfg.EPGRetentionDays())
 	}
 }
 


### PR DESCRIPTION
## What

- Default value of `EPG_RETENTION_DAYS` changed from **10 to 3** days
- EPG retention window is now `now - 1h` ... `now + 3 days` (programmes starting later than that are dropped)
- Env var still overrides the default

## Files

- `internal/config/config.go` — default 10 → 3
- `internal/config/config_test.go` — `TestEPGRetentionDaysDefault` updated
- `AGENTS.md`, `README.md` — docs updated

## Tests

- `go test ./... -count=1` — all packages pass
- `go vet ./...` — clean
